### PR TITLE
Chore/readme grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm i -g zx
 ## Documentation
 
 Write your scripts in a file with `.mjs` extension in order to 
-be able to use `await` on top level. In you prefer `.js` extension,
+be able to use `await` on top level. If you prefer `.js` extension,
 wrap your script in something like `void async function () {...}()`.
 
 Add next shebang at the beginning of your script:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ await $`ssh medv.io uptime`
 
 Bash is great, but when it comes to writing scripts, 
 people usually choose a more convenient programming languages.
-JavaScript is a perfect choose, but standard Node.js library 
+JavaScript is a perfect choice, but standard Node.js library 
 requires additional hassle before using. `zx` package provides
 useful wrappers around `child_process` and gives sensible defaults. 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ await $`ssh medv.io uptime`
 ```
 
 Bash is great, but when it comes to writing scripts, 
-people usually choose a more convenient programming languages.
+people usually choose a more convenient programming language.
 JavaScript is a perfect choice, but standard Node.js library 
 requires additional hassle before using. `zx` package provides
 useful wrappers around `child_process` and gives sensible defaults. 


### PR DESCRIPTION
Fixes N / A

Just a couple small, minor grammar tweaks in the README.

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR

----

I tried to run tests just to be safe, but `yarn test` and `npm run test` both failed for me with
```sh
% npm run test

> zx@1.0.2 test /Users/owenbuckley/Workspace/github/forks/zx
> zx test.mjs

sh: zx: command not found
```

Couldn't find any notes in _contributing.md_ but let me know if there is anything else you need.