### PR TITLE
Using file:/// for loading files using absolute path

### DIFF
--- a/zx.mjs
+++ b/zx.mjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 
 // Copyright 2021 Google LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,6 +47,9 @@ try {
     }
   } else if (firstArg.startsWith('http://') || firstArg.startsWith('https://')) {
     await scriptFromHttp(firstArg)
+
+  } else if (firstArg.startsWith('file:///')) {
+    await import(firstArg.substring(7))
   } else {
     await import(join(process.cwd(), firstArg))
   }


### PR DESCRIPTION
Using file:/// for loading files using absolute path

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR