### PR TITLE
test.mjs: Keep running to show all fails

### DIFF
--- a/test.mjs
+++ b/test.mjs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+let FAILS = 0
 function assert(cond, msg) {
   if (cond) return
   console.error('Assertion failed')
   if (msg) console.error(msg)
-  process.exit(1)
-
+  FAILS += 1
 }
 
 {
@@ -73,3 +73,6 @@ function assert(cond, msg) {
   process.env.FOO = 'hi; exit 1'
   await $`echo $FOO`
 }
+
+if (FAILS > 0)
+  process.exit(1)


### PR DESCRIPTION
I don't think this deserves an issue, as it's not user-facing at all. Anyways, this lets the tests keep running after the first fail, so the developer can see all the ways a change messes things up.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR