### PR TITLE
/bin/bash can't be promised.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ await $`cd ${os.homedir()} && mkdir example`
 
 ### `$.shell`
 
-Specifies what shell is used. Default is `/bin/bash`.
+Specifies what shell is used. Default is `type bash`.
 
 ```js
 $.shell = '/usr/bin/bash'

--- a/index.mjs
+++ b/index.mjs
@@ -70,7 +70,7 @@ export function $(pieces, ...args) {
 }
 
 $.verbose = true
-$.shell = '/bin/bash'
+$.shell = child_process.execSync('which bash', { encoding: 'utf8' }).trim()
 $.cwd = undefined
 
 export function cd(path) {


### PR DESCRIPTION
Pick up the right path of bash, instead of depending on `/bin/bash`.