### PR TITLE
custom promisify implementation for readline

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -14,7 +14,6 @@
 
 import {existsSync} from 'fs'
 import {exec, execSync} from 'child_process'
-import {promisify} from 'util'
 import {createInterface} from 'readline'
 import {default as nodeFetch} from 'node-fetch'
 import chalk from 'chalk'
@@ -103,7 +102,7 @@ export async function question(query, options) {
     output: process.stdout,
     completer,
   })
-  const question = promisify(rl.question).bind(rl)
+  const question = (q) => new Promise((resolve) => rl.question(q, resolve));
   let answer = await question(query)
   rl.close()
   return answer


### PR DESCRIPTION
Fixes #36

Custom promisify fixes the issue with readline breaking in node <= v15.7.0

This might be happening because readline's question function has a callback function. And instead of returning error in the first argument it has the answer itself ? 

- [x] Tests pass
- [x] Appropriate changes to README are included in PR