### PR TITLE
Fix TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,8 @@ interface $ {
   verbose: boolean
   shell: string
   cwd: string
+  prefix: string
+  quote: (input: string) => string
 }
 
 export const $: $

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "files": [
     "*.mjs",
-    "*.js"
+    "*.js",
+    "*.d.ts"
   ],
   "repository": "google/zx",
   "author": "Anton Medvedev <anton@medv.io>",


### PR DESCRIPTION
This PR fixes type definitions by:

1. Including them in the package.
2. Adding missing `$.prefix` and `$.quote`.