### PR TITLE
index.mjs: warn about non-bash

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -76,6 +76,7 @@ try {
 } catch (e) {
   // Bash not found, no prefix.
   $.prefix = ''
+  console.warn("Bash not found, using nodejs default. Quoting is now unreliable.")
 }
 $.quote = shq
 $.cwd = undefined


### PR DESCRIPTION
A warning is necessary to avoid future Windows-user issues.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR