### PR TITLE
Don't require the argument `query` for `question()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This is a wrapper around [readline](https://nodejs.org/api/readline.html) packag
 ```ts
 type QuestionOptions = { choices: string[] }
 
-function question(query: string, options?: QuestionOptions): Promise<string>
+function question(query?: string, options?: QuestionOptions): Promise<string>
 ```
 
 Usage:

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ export function cd(path: string)
 
 type QuestionOptions = { choices: string[] }
 
-export function question(query: string, options?: QuestionOptions): Promise<string>
+export function question(query?: string, options?: QuestionOptions): Promise<string>
 
 export class ProcessOutput {
   readonly exitCode: number

--- a/index.mjs
+++ b/index.mjs
@@ -105,7 +105,7 @@ export async function question(query, options) {
     output: process.stdout,
     completer,
   })
-  const question = (q) => new Promise((resolve) => rl.question(q, resolve))
+  const question = (q) => new Promise((resolve) => rl.question(q ?? '', resolve))
   let answer = await question(query)
   rl.close()
   return answer


### PR DESCRIPTION
Improve readability when a query is not needed. From usage in https://github.com/google/zx/issues/61#issuecomment-839551685.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR