### PR TITLE
feat: add $.env and $.argv

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,19 @@ Specifies verbosity. Default is `true`.
 In verbose mode, the `zx` prints all executed commands alongside with their outputs.
 This is the same as using `set -x` in Bash.
 
+### `$.env`
+
+It's an alias for `process.env`.
+
+### `$.argv`
+
+It is an array containing arguments received by the current script.
+
+```shell
+./script.mjs hello world
+# $.argv = ['./script/mjs', 'hello', 'world']
+```
+
 ### `__filename` & `__dirname`
 
 In [ESM](https://nodejs.org/api/esm.html) modules, Node.js does not provide

--- a/README.md
+++ b/README.md
@@ -209,16 +209,22 @@ This is the same as using `set -x` in Bash.
 
 ### `$.env`
 
-It's an alias for `process.env`.
+An alias for `process.env`.
 
 ### `$.argv`
 
-It is an array containing arguments received by the current script.
+An array containing arguments received by the current script.
 
 ```shell
 ./script.mjs hello world
 # $.argv = ['./script/mjs', 'hello', 'world']
 ```
+
+The difference between `$.argv` and `process.argv` in a **zx script**:
+
+- `process.argv` is `[node executable path, zx path, script path, ...arguments to script]`,
+
+- `$.argv` is `[script path, ...arguments to script]`.
 
 ### `__filename` & `__dirname`
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ An array containing arguments received by the current script.
 
 ```shell
 ./script.mjs hello world
-# $.argv = ['./script/mjs', 'hello', 'world']
+# $.argv == ['./script.mjs', 'hello', 'world']
 ```
 
 The difference between `$.argv` and `process.argv` in a **zx script**:

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,8 @@ interface $ {
   shell: string
   cwd: string
   prefix: string
+  env: { [key: string]: string | undefined }
+  argv: string[]
   quote: (input: string) => string
 }
 

--- a/index.mjs
+++ b/index.mjs
@@ -80,6 +80,8 @@ try {
 }
 $.quote = shq
 $.cwd = undefined
+$.env = process.env
+$.argv = process.argv.slice(2)
 
 export function cd(path) {
   if ($.verbose) console.log('$', colorize(`cd ${path}`))


### PR DESCRIPTION
For env and argv are often used in writing scripts, maybe it's more convenient to think of these two as first-class variables.

`$.env` is just an alias for `process.env`

`$.argv` is an array containing arguments received by the current script.

```shell
./script.mjs hello world
# $.argv = ['./script/mjs', 'hello', 'world']
```

Yeah the first two argvs (the path of node and the path of zx) is not here because the most use cases don't care them, and in very few scenarios that need to be used, `process.argv` can help.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR