### PR TITLE
Added node version to the readme under the install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ gives sensible defaults.
 npm i -g zx
 ```
 
+(depends on node >= 14.8.0)
+
 ## Documentation
 
 Write your scripts in a file with `.mjs` extension in order to 


### PR DESCRIPTION
After running in to some issues running zx scripts on my machine, I realized I was using node v12. I added the node version to the readme just to make this experience a little smoother for any new users who may be less experienced with node. 


- [x] Appropriate changes to README are included in PR