### PR TITLE
Fix when child stdio is over

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -63,9 +63,10 @@ export function $(pieces, ...args) {
       combined += data
     })
     child.on('exit', code => {
-      (code === 0 ? resolve : reject)(
-        new ProcessOutput({code, stdout, stderr, combined, __from})
-      )
+      const cb = (code === 0 ? resolve : reject)
+      child.on('close', () => {
+        cb(new ProcessOutput({code, stdout, stderr, combined, __from}))
+      })
     })
   })
 }


### PR DESCRIPTION
ProcessOutput is returned even though the stdio of the child process is not finished.

``` javascript
#!/usr/bin/env zx

for(let i=0; i<5; i++) {
    $`date`.then(r => console.log(i, r.toString()))
}
```
result
```
./main.mjs  
$ date
$ date
$ date
$ date
$ date
2021년 5월 16일 일요일 17시 16분 46초 KST
2021년 5월 16일 일요일 17시 16분 46초 KST
2021년 5월 16일 일요일 17시 16분 46초 KST
0 2021년 5월 16일 일요일 17시 16분 46초 KST

1 2021년 5월 16일 일요일 17시 16분 46초 KST

2 2021년 5월 16일 일요일 17시 16분 46초 KST

3 
4 
2021년 5월 16일 일요일 17시 16분 46초 KST
2021년 5월 16일 일요일 17시 16분 46초 KST
```
somtimes
```
./main.mjs 
$ date
$ date
$ date
$ date
$ date
2021년 5월 16일 일요일 17시 55분 13초 KST
2021년 5월 16일 일요일 17시 55분 13초 KST
2021년 5월 16일 일요일 17시 55분 13초 KST
2021년 5월 16일 일요일 17시 55분 13초 KST
0 2021년 5월 16일 일요일 17시 55분 13초 KST

1 2021년 5월 16일 일요일 17시 55분 13초 KST

2 2021년 5월 16일 일요일 17시 55분 13초 KST

3 2021년 5월 16일 일요일 17시 55분 13초 KST

4 
2021년 5월 16일 일요일 17시 55분 13초 KST
```

after fixing
```
node zx.mjs bug.mjs                                                                                        ✔  base   17:55:13  
$ date
$ date
$ date
$ date
$ date
2021년 5월 16일 일요일 17시 57분 04초 KST
2021년 5월 16일 일요일 17시 57분 04초 KST
2021년 5월 16일 일요일 17시 57분 04초 KST
2021년 5월 16일 일요일 17시 57분 04초 KST
2021년 5월 16일 일요일 17시 57분 04초 KST
3 2021년 5월 16일 일요일 17시 57분 04초 KST

2 2021년 5월 16일 일요일 17시 57분 04초 KST

1 2021년 5월 16일 일요일 17시 57분 04초 KST

0 2021년 5월 16일 일요일 17시 57분 04초 KST

4 2021년 5월 16일 일요일 17시 57분 04초 KST
```



References
https://stackoverflow.com/questions/37522010/difference-between-childprocess-close-exit-events

