### PR TITLE
ci: configure semantic-release pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,42 @@
+name: CI-CD
+on: [push]
+jobs:
+  test_push:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: npm install
+        run: npm i
+
+      - name: Run unit tests
+        run: npm test
+
+  release:
+    name: Release
+    # https://github.community/t/trigger-job-on-tag-push-only/18076
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: test_push
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout # full depth checkout is needed to get all tags for semantic release
+        uses: actions/checkout@v2
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
+          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}
+          GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
+          GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMITTER_NAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI-CD
-on: [push]
+on:
+  push:
+    branches:
+      - master
 jobs:
   test_push:
     runs-on: ubuntu-20.04
@@ -14,7 +17,7 @@ jobs:
         with:
           node-version: 14
 
-      - name: npm install
+      - name: Install package deps
         run: npm i
 
       - name: Run unit tests
@@ -22,8 +25,6 @@ jobs:
 
   release:
     name: Release
-    # https://github.community/t/trigger-job-on-tag-push-only/18076
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: test_push
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,12 @@ jobs:
       - name: Checkout # full depth checkout is needed to get all tags for semantic release
         uses: actions/checkout@v2
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -40,3 +44,4 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMITTER_NAME }}
+        run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,23 @@
+{
+  "branches": ["master"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          {"type": "docs", "release": "patch"},
+          {"type": "refactor", "release": "patch"}
+        ],
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
+        }
+      }
+    ],
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    "@semantic-release/github",
+    "@semantic-release/git"
+  ]
+}


### PR DESCRIPTION
closes #64

Adds `semantic-release` action.
env config example:
```
      GITHUB_TOKEN: 'token'
      GH_TOKEN: 'token'
      NPM_TOKEN: 'token'
      GIT_AUTHOR_EMAIL: 'mailbox@antongolub.ru'
      GIT_COMMITTER_EMAIL: 'mailbox@antongolub.ru'
      GIT_AUTHOR_NAME: '@antongolub'
      GIT_COMMITTER_NAME: '@antongolub'
```
