### PR TITLE
Added --help, --quiet and --shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ zx ./script.mjs
 When using `zx` via the executable or a shebang, all of the functions
 (`$`, `cd`, `fetch`, etc) are available straight away without any imports.
 
+### Options
+
+| option | Description |
+|--------|-------------|
+| `-v, -V, --version` | Print zx version |
+| `-h, -H, --help` | Print usage |
+| `-q, -Q, --quiet` | Run with [`$.verbose`](#verbose) set to `false`|
+| `-s, -S, --shell` | Specify [`$.shell`](#shell) |
+
+Use zsh.
+```bash
+zx -s zsh ./script.mjs
+```
+
+Run with [`$.verbose`](#verbose) using zsh.
+```bash
+zx -q -s zsh ./script.mjs
+```
+
 ### ``$`command` ``
 
 Executes a given string using the `exec` function from the

--- a/zx.mjs
+++ b/zx.mjs
@@ -114,11 +114,6 @@ try {
     await parseArgv();
   
 
-  if (['-v', '-V', '--version'].includes(firstArg)) {
-    console.log(`zx version ${createRequire(import.meta.url)('./package.json').version}`)
-    process.exit(0)
-  }
-
   if (typeof firstArg === 'undefined') {
     let ok = await scriptFromStdin()
     if (!ok) {

--- a/zx.mjs
+++ b/zx.mjs
@@ -19,7 +19,6 @@ import os, {tmpdir} from 'os'
 import {promises as fs} from 'fs'
 import {createRequire} from 'module'
 import url from 'url'
-import {v4 as uuid} from 'uuid'
 import {$, cd, question, fetch, chalk, sleep, ProcessOutput} from './index.mjs'
 import which from "which"
 


### PR DESCRIPTION
Closes #16 

- [x] Tests pass
- [x] Appropriate changes to README are included in PR

## Adds 3 more options and refines argv handling.

| option | Description |
|--------|-------------|
| `-h, -H, --help` | Print usage |
| `-q, -Q, --quiet` | Run with [`$.verbose`](#verbose) set to `false`|
| `-s, -S, --shell` | Specify [`$.shell`](#shell) |

If `test.mjs` contains the following:
```bash
console.log((await $`echo $0`).stdout);
```
Standard:
```bash
zx ./test.mjs
# Result
$ echo $0
/bin/bash
/bin/bash
```

Use other shell:
```bash
zx -s zsh ./test.mjs
# Result
$ echo $0
/usr/local/bin/zsh
/usr/local/bin/zsh
```

Run with `$.verbose = false` using zsh:
```bash
zx -q -s zsh ./test.mjs
# Result
/usr/local/bin/zsh
```
