### PR TITLE
Fix type definition file (#110)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,9 @@ interface $ {
   quote: (input: string) => string
 }
 
+// @ts-ignore because #110(https://github.com/google/zx/issues/110)
+export const $: $
+
 export type cd = (path: string) => void
 export type sleep = (ms: number) => Promise<void>
 export type question = (query?: string, options?: QuestionOptions) => Promise<string>


### PR DESCRIPTION
Fixes #110 

I think the reason is that `export const $: $` deleted from index.d.ts. ([ref](https://github.com/google/zx/commit/934b64a7644b424c4151d91ec64de49863845366#diff-7aa4473ede4abd9ec099e87fec67fd57afafaf39e05d493ab4533acc38547eb8L27))

To fix this, I added `export const $: $` to the original position. But now `zx hoge.ts` gives me an error, so I added another `// @ts-ignore`.

```
❯ zx echo.ts                       
$ tsc --target esnext --module esnext --moduleResolution node /Users/korosuke613/ghq/github.com/korosuke613/playground/zx/throw-issues/echo.ts
node_modules/zx/index.d.ts(31,18): error TS1254: A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference.
Error: 
    at importPath (file:///Users/korosuke613/.asdf/installs/nodejs/14.16.1/.npm/lib/node_modules/zx/zx.mjs:120:12)
```

- [x] Tests pass
- [x] Appropriate changes to README are included in PR