### PR TITLE
fix: make internal npx invocation compatible with npm v6

### DIFF
--- a/zx.mjs
+++ b/zx.mjs
@@ -117,7 +117,7 @@ async function importPath(filepath, origin = filepath) {
   if (ext === '.ts') {
     let {dir, name} = parse(filepath)
     let outFile = join(dir, name + '.mjs')
-    await run`npx --yes tsc --target esnext --module esnext --moduleResolution node ${filepath}`
+    await run`npm_config_yes=true npx tsc --target esnext --module esnext --moduleResolution node ${filepath}`
     await fs.rename(join(dir, name + '.js'), outFile)
     let wait = importPath(outFile, filepath)
     await fs.rm(outFile)


### PR DESCRIPTION
https://omrilotan.medium.com/npx-breaking-on-ci-b9f3f61d4676

relates https://github.com/google/zx/commit/0cf9b9dc92c28f59f25e3db81c62846c37bcef82

- [x] Tests pass