### PR TITLE
Fix issue #127 - calling `pipe` of resolved `ProcessPromise` should throw `Error` instead of producing empty output

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -57,6 +57,7 @@ export function $(pieces, ...args) {
       })
     })
   })
+  promise.then(() => promise.resolved())
   if (process.stdin.isTTY) {
     process.stdin.pipe(child.stdin)
   }
@@ -145,6 +146,7 @@ export class ProcessPromise extends Promise {
   child = undefined
   _stop = () => void 0
   _nothrow = false
+  _resolved = false
 
   get stdin() {
     return this.child.stdin
@@ -164,7 +166,14 @@ export class ProcessPromise extends Promise {
       .catch(p => p.exitCode)
   }
 
+  resolved() {
+    this._resolved = true
+  }
+
   pipe(dest) {
+    if (this._resolved === true) {
+      throw new Error("The pipe() method shouldn't be called after promise is already resolved/awaited!")
+    }
     if (typeof dest === 'string') {
       throw new Error('The pipe() method does not take strings. Forgot $?')
     }

--- a/test.mjs
+++ b/test.mjs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {strict as assert} from 'assert'
+import {inspect} from 'util'
 
 { // Only stdout is used during command substitution
   let hello = await $`echo Error >&2; echo Hello`
@@ -121,9 +122,9 @@ import {strict as assert} from 'assert'
   } catch (e) {
     console.log("This was expected", e)
   }
-  assert(processOutput.exitCode === 0)
-  assert(processOutput.stdout === '') // this is unexpected - intuitively would expect "Hello"
-  assert(processOutput.stderr === '')
+  if (processOutput) {
+    assert.fail('Expected failure, but got ' + processOutput[inspect.custom]())
+  }
 }
 
 { // ProcessOutput thrown as error

--- a/test.mjs
+++ b/test.mjs
@@ -111,6 +111,21 @@ import {strict as assert} from 'assert'
   }
 }
 
+{
+  const processPromise = $`echo "Hello"`;
+  await processPromise // after awaiting promise, pipe doesn't receive output
+  let processOutput;
+  try {
+    processOutput = await processPromise
+      .pipe($`less`)
+  } catch (e) {
+    console.log("This was expected", e)
+  }
+  assert(processOutput.exitCode === 0)
+  assert(processOutput.stdout === '') // this is unexpected - intuitively would expect "Hello"
+  assert(processOutput.stderr === '')
+}
+
 { // ProcessOutput thrown as error
   let err
   try {


### PR DESCRIPTION
Fixes #127 using fail-fast approach - if `pipe` is called on resolved/awaited `ProcessPromise`, then throw `Error` instead of producing empty output

- [x] Tests pass
- [x] No changes to behaviour documented in README

