### PR TITLE
refactor: remove useless code for fetch

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -123,7 +123,7 @@ export async function question(query, options) {
   return answer
 }
 
-export async function fetch(url, init) {
+export function fetch(url, init) {
   if ($.verbose) {
     if (typeof init !== 'undefined') {
       console.log('$', colorize(`fetch ${url}`), init)


### PR DESCRIPTION
node-fetch library returns a Promise object. The fetch function does not need to use async. Currently async is redundant

- [x]  Tests pass
- [x]  No changes to behaviour documented in README

