### PR TITLE
fix(types): declare global injects as vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /.idea/
 package-lock.json
+yarn.lock

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,14 +70,14 @@ export const question: question
 export const sleep: sleep
 
 declare global {
-  const $: $
-  const cd: cd
-  const chalk: typeof _chalk
+  var $: $
+  var cd: cd
+  var chalk: typeof _chalk
   // @ts-ignore
-  const fetch: typeof _fetch
-  const fs: fs
-  const nothrow: nothrow
-  const os: typeof _os
-  const question: question
-  const sleep: sleep
+  var fetch: typeof _fetch
+  var fs: fs
+  var nothrow: nothrow
+  var os: typeof _os
+  var question: question
+  var sleep: sleep
 }


### PR DESCRIPTION
Global injects should be declared as vars so that they can be overridden if needed. 
Like here: https://github.com/microsoft/TypeScript/blob/main/lib/lib.dom.d.ts#L19303)
- [x] Tests pass