### PR TITLE
feat: add `fs.constants` field to global `fs`, add missed `fs` export

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ console.log(chalk.blue('Hello world!'))
 
 #### `fs` package
 
-The [fs](https://nodejs.org/api/fs.html) package.
+The `promises` of [fs](https://nodejs.org/api/fs.html#fs_promises_api) package.
 
 ```js
 let content = await fs.readFile('./package.json')

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@
 
 import {ChildProcess} from 'child_process'
 import {Readable, Writable} from 'stream'
-import {createReadStream, createWriteStream, promises as _fs} from 'fs'
+import {createReadStream, createWriteStream, promises as fsPromises, constants as fsConstants} from 'fs'
 import * as _os from 'os'
 import * as _chalk from 'chalk'
 import _fetch from 'node-fetch'
@@ -50,7 +50,8 @@ export class ProcessOutput {
 export type QuestionOptions = { choices: string[] }
 
 type cd = (path: string) => void
-type fs = typeof _fs & {
+type fs = typeof fsPromises & {
+  constants: typeof fsConstants
   createWriteStream: typeof createWriteStream
   createReadStream: typeof createReadStream
 }

--- a/index.mjs
+++ b/index.mjs
@@ -16,7 +16,8 @@ import {
   createReadStream,
   createWriteStream,
   existsSync,
-  promises as fs
+  promises as fsPromises,
+  constants as fsConstants,
 } from 'fs'
 import os from 'os'
 import {promisify, inspect} from 'util'
@@ -103,6 +104,8 @@ export function cd(path) {
   }
   $.cwd = path
 }
+
+export const fs = {...fsPromises, constants: fsConstants, createWriteStream, createReadStream}
 
 export async function question(query, options) {
   let completer = undefined
@@ -238,7 +241,7 @@ Object.assign(global, {
   cd,
   chalk,
   fetch,
-  fs: {...fs, createWriteStream, createReadStream},
+  fs,
   nothrow,
   os,
   question,


### PR DESCRIPTION
closes #146

- [x] Tests pass
- [x] Docs