### PR TITLE
fix: README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The [fs](https://nodejs.org/api/fs.html#fs_promises_api) package.
 let content = await fs.readFile('./package.json')
 ```
 
-### `os` package
+#### `os` package
 
 The [os](https://nodejs.org/api/os.html) package.
 


### PR DESCRIPTION
The heading "`os` package" should be under the "Packages".

- [x] Tests pass
- [x] Appropriate changes to README are included in PR