### PR TITLE
docs(README.md): update Node.js version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm i -g zx
 
 ### Requirement
 
-Node.js >= 14.8.0
+Node.js >= 15.0.0
 
 ## Documentation
 


### PR DESCRIPTION
Since v1.15.1, zx requires Node.js v15 or higher.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [x] Appropriate changes to README are included in PR