### PR TITLE
Fix CLI options such as --quiet

### DIFF
--- a/test.mjs
+++ b/test.mjs
@@ -91,6 +91,11 @@ import {strict as assert} from 'assert'
   await $`node zx.mjs examples/typescript.ts`
 }
 
+{ // Quiet mode is working
+  let {stdout} = await $`node zx.mjs --quiet examples/markdown.md`
+  assert(!stdout.includes('whoami'))
+}
+
 { // Pipes are working
   let {stdout} = await $`echo "hello"`
     .pipe($`awk '{print $1" world"}'`)

--- a/zx.mjs
+++ b/zx.mjs
@@ -26,8 +26,8 @@ try {
     console.log(`zx version ${createRequire(import.meta.url)('./package.json').version}`)
     process.exit(0)
   }
-  let firstArg = process.argv[2]
-  if (typeof firstArg === 'undefined' || firstArg[0] === '-') {
+  let firstArg = process.argv.slice(2).find(a => !a.startsWith('--'));
+  if (typeof firstArg === 'undefined' || firstArg === '-') {
     let ok = await scriptFromStdin()
     if (!ok) {
       printUsage()


### PR DESCRIPTION
Currently, when a CLI option is passed, you just get the usage instructions back:

```
yarn zx --quiet myscript.ts
usage: zx [--quiet] [--shell=<path>]
          [--prefix=<command>]
          <script>
```

- [x] Tests pass
- [x] Appropriate changes to README are included in PR