### PR TITLE
Run script from path

### DIFF
--- a/test.mjs
+++ b/test.mjs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {strict as assert} from 'assert'
+import path from 'path'
 
 { // Only stdout is used during command substitution
   let hello = await $`echo Error >&2; echo Hello`
@@ -137,6 +138,30 @@ import {strict as assert} from 'assert'
   const {name, version} = require('./package.json')
   assert(typeof name === 'string')
   console.log(chalk.black.bgYellowBright(` ${name} version is ${version} `))
+}
+
+{ // executes a script from PATH.
+  const isWindows = process.platform === 'win32'
+  const oldPath = process.env.PATH
+
+  const envPathSeparator = isWindows ? ';' : ':'
+  process.env.PATH +=  envPathSeparator + path.resolve('/tmp/')
+
+  const toPOSIXPath = (_path) =>
+    _path.split(path.sep).join(path.posix.sep)
+
+  const zxPath = path.resolve('./zx.mjs')
+  const zxLocation = isWindows ? toPOSIXPath(zxPath) : zxPath
+  const scriptCode = `#!/usr/bin/env ${zxLocation}\nconsole.log('The script from path runs.')`
+
+  try {
+    await $`echo ${scriptCode}`
+      .pipe(fs.createWriteStream('/tmp/script-from-path.js', { mode: 0o744 }))
+    await $`script-from-path.js`
+  } finally {
+    process.env.PATH = oldPath
+    fs.rm('/tmp/script-from-path.js')
+  }
 }
 
 console.log(chalk.greenBright(' 🍺 Success!'))

--- a/test.mjs
+++ b/test.mjs
@@ -140,7 +140,7 @@ import path from 'path'
   console.log(chalk.black.bgYellowBright(` ${name} version is ${version} `))
 }
 
-{ // executes a script from PATH.
+{ // Executes a script from PATH.
   const isWindows = process.platform === 'win32'
   const oldPath = process.env.PATH
 
@@ -156,11 +156,11 @@ import path from 'path'
 
   try {
     await $`echo ${scriptCode}`
-      .pipe(fs.createWriteStream('/tmp/script-from-path.js', { mode: 0o744 }))
-    await $`script-from-path.js`
+      .pipe(fs.createWriteStream('/tmp/script-from-path', { mode: 0o744 }))
+    await $`script-from-path`
   } finally {
     process.env.PATH = oldPath
-    fs.rm('/tmp/script-from-path.js')
+    fs.rm('/tmp/script-from-path')
   }
 }
 

--- a/zx.mjs
+++ b/zx.mjs
@@ -42,7 +42,7 @@ try {
     } else if (firstArg.startsWith('file:///')) {
       filepath = url.fileURLToPath(firstArg)
     } else {
-      filepath = join(process.cwd(), firstArg)
+      filepath = resolve(firstArg)
     }
     await importPath(filepath)
   }


### PR DESCRIPTION
Continuing the discussion  from #28, this PR includes:

- A test that runs a script from the PATH environmental variable.
- A change in the default case of parsing the first argument to use `filepath = resolve(firstArg)` instead of `filepath = join(process.cwd(), firstArg)` because this allows to run a script from PATH on Windows with Git bash. zx was able to run a script from PATH on Linux, even before this change, because it didn't use the default case (I think).

The problem, though, is that GitHub actions tests on Ubuntu so the test does not confirm that it works on Windows. If Windows support is important, we can configure, in the future, another job that runs the tests on Windows (?)—and change some of them because they fail on Windows.