### PR TITLE
Fix split regex for stack.split()

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -24,7 +24,7 @@ import chalk from 'chalk'
 import minimist from 'minimist'
 
 export function $(pieces, ...args) {
-  let __from = (new Error().stack.split('at ')[2]).trim()
+  let __from = (new Error().stack.split(/^\s*at\s/m)[2]).trim()
   let cmd = pieces[0], i = 0
   let verbose = $.verbose
   while (i < args.length) {
@@ -105,7 +105,7 @@ $.cwd = undefined
 export function cd(path) {
   if ($.verbose) console.log('$', colorize(`cd ${path}`))
   if (!fs.existsSync(path)) {
-    let __from = (new Error().stack.split('at ')[2]).trim()
+    let __from = (new Error().stack.split(/^\s*at\s/m)[2]).trim()
     console.error(`cd: ${path}: No such directory`)
     console.error(`    at ${__from}`)
     process.exit(1)


### PR DESCRIPTION
The code `new Error().stack.split('at ')` in `cd()` gives an incorrect output when `cd` is called from a function whose name ends with "at". For example:
```js
function cat() {
    cd("cc");
}

function f() {
    cat();
}

f();
/*
$ cd cc
cd: cc: No such directory
    at c
*/
```