### PR TITLE
Update Node version requirement (correctly).

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm i -g zx
 
 ### Requirement
 
-Node.js >= 14.13.0
+Node.js >= 14.13.1
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "zx": "zx.mjs"
   },
   "engines": {
-    "node": ">= 14.13.0"
+    "node": ">= 14.13.1"
   },
   "scripts": {
     "test": "node zx.mjs test.mjs",


### PR DESCRIPTION
Fixes #214 

It turns out I noted the Node version requirement incorrectly. As you pointed out [here](https://github.com/sindresorhus/globby/blob/6e099869e77240f705a951b6a80c09d3bab55423/package.json#L16), it's 14.13.1, not 14.13.0.

Sorry! 😅

- [x] Tests pass
- [x] Appropriate changes to README are included in PR