### PR TITLE
Fix the `cd()` to set the cwd correctly when passed a relative path

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -133,15 +133,21 @@ if (typeof argv.prefix === 'string') {
 $.quote = quote
 $.cwd = undefined
 
-export function cd(path) {
-  if ($.verbose) console.log('$', colorize(`cd ${path}`))
-  if (!fs.existsSync(path)) {
+export function cd(_path) {
+  if ($.verbose) console.log('$', colorize(`cd ${_path}`))
+  let cwd
+  if (path.isAbsolute(_path)) {
+    cwd = _path
+  } else {
+    cwd = path.join($.cwd ?? process.cwd(), _path)
+  }
+  if (!fs.existsSync(cwd)) {
     let __from = (new Error().stack.split(/^\s*at\s/m)[2]).trim()
-    console.error(`cd: ${path}: No such directory`)
+    console.error(`cd: ${_path}: No such directory`)
     console.error(`    at ${__from}`)
     process.exit(1)
   }
-  $.cwd = path
+  $.cwd = cwd
 }
 
 export async function question(query, options) {

--- a/test.mjs
+++ b/test.mjs
@@ -154,6 +154,17 @@ import {strict as assert, deepEqual} from 'assert'
   assert(await $`[[ -f ${__filename} ]]`.exitCode === 0)
 }
 
+{
+  // cd() is working
+  assert($.cwd === undefined)
+  cd('/usr/local/lib')
+  assert($.cwd === '/usr/local/lib')
+  cd('..')
+  assert($.cwd === '/usr/local')
+  cd('..'); cd('..')
+  assert($.cwd === '/')
+}
+
 { // nothrow() doesn't throw
   let {exitCode} = await nothrow($`exit 42`)
   assert(exitCode === 42)

--- a/test.mjs
+++ b/test.mjs
@@ -163,6 +163,7 @@ import {strict as assert, deepEqual} from 'assert'
   assert($.cwd === '/usr/local')
   cd('..'); cd('..')
   assert($.cwd === '/')
+  $.cwd = undefined
 }
 
 { // nothrow() doesn't throw


### PR DESCRIPTION
Fixes #223 partially.

As the title says, this PR fixes the `cd()` to set the cwd correctly when passed a relative path.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR