### PR TITLE
Remove @types/node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@types/fs-extra": "^9.0.13",
         "@types/minimist": "^1.2.2",
         "@types/node": "^17.0",
-        "@types/node-fetch": "^3.0.2",
         "chalk": "^5.0.0",
         "fs-extra": "^10.0.0",
         "globby": "^13.1.1",
@@ -78,15 +77,6 @@
       "version": "17.0.16",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.16.tgz",
       "integrity": "sha512-ydLaGVfQOQ6hI1xK2A5nVh8bl0OGoIfYMxPWHqqYe9bTkWCfqiVvZoh2I/QF2sNSkZzZyROBoTefIEI+PB6iIA=="
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz",
-      "integrity": "sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==",
-      "deprecated": "This is a stub types definition. node-fetch provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "node-fetch": "*"
-      }
     },
     "node_modules/braces": {
       "version": "3.0.2",
@@ -600,14 +590,6 @@
       "version": "17.0.16",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.16.tgz",
       "integrity": "sha512-ydLaGVfQOQ6hI1xK2A5nVh8bl0OGoIfYMxPWHqqYe9bTkWCfqiVvZoh2I/QF2sNSkZzZyROBoTefIEI+PB6iIA=="
-    },
-    "@types/node-fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz",
-      "integrity": "sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==",
-      "requires": {
-        "node-fetch": "*"
-      }
     },
     "braces": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@types/fs-extra": "^9.0.13",
     "@types/minimist": "^1.2.2",
     "@types/node": "^17.0",
-    "@types/node-fetch": "^3.0.2",
     "chalk": "^5.0.0",
     "fs-extra": "^10.0.0",
     "globby": "^13.1.1",


### PR DESCRIPTION
Remove types for node-fetch because the package is deprecated. https://www.npmjs.com/package/@types/node-fetch. The 3.0.3 version from the lock file is empty when you install it.