### PR TITLE
README.md: HTTP => HTTPS, second try

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ await $`pwd` // outputs /tmp
 A wrapper around the [node-fetch](https://www.npmjs.com/package/node-fetch) package.
 
 ```js
-let resp = await fetch('http://wttr.in')
+let resp = await fetch('https://wttr.in')
 if (resp.ok) {
   console.log(await resp.text())
 }


### PR DESCRIPTION
Checked the link, skipping the redirect HTTP => HTTPS this way 0:-)

~~Fixes #<issue_number_goes_here>~~

- [x] ~~Tests pass~~ N/A, since they weren't touched, so state as before
- [x] Appropriate changes to README are included in PR

#269 was unexpectedly closed, so here is another try :)