### PR TITLE
fix: Calling kill when child is undefined throws

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -234,6 +234,7 @@ export class ProcessPromise extends Promise {
   }
 
   async kill(signal = 'SIGTERM') {
+    if (!this.child) { return }
     this.catch(_ => _)
     let children = await psTree(this.child.pid)
     for (const p of children) {


### PR DESCRIPTION
I will intermittently get an error here. If there is no child process, then there is nothing to kill.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR