### PR TITLE
Add types exports for typescript@next

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,18 @@
   "description": "A tool for writing better scripts.",
   "main": "./index.mjs",
   "exports": {
-    ".": "./index.mjs",
-    "./globals": "./globals.mjs",
-    "./experimental": "./experimental.mjs"
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.mjs"
+    },
+    "./globals": {
+      "types": "./globals.d.ts",
+      "import": "./globals.mjs"
+    },
+    "./experimental": {
+      "types": "./experimental.d.ts",
+      "import": "./experimental.mjs"
+    }
   },
   "types": "index.d.ts",
   "bin": {


### PR DESCRIPTION
when using typescript@^4.7.0-dev.20220302 which version supported esm.
<img width="1042" alt="image" src="https://user-images.githubusercontent.com/21997724/156324602-b43a1be6-e8d5-43a7-93d2-767377a7547c.png">
webstorm will show this error. Fix it by editing `package.json`, no other effect.
> https://www.typescriptlang.org/docs/handbook/esm-node.html#:~:text=If%20you%20need%20to%20point%20to%20a%20different%20location%20for%20your%20type%20declarations%2C%20you%20can%20add%20a%20%22types%22%20import%20condition.