### PR TITLE
feature: add --dotenv arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ if ((await nothrow($`[[ -d path ]]`)).exitCode == 0) {
   ...
 }
 ```
+#### `dotenv`
+
+File path to a env file to preload, if `--dotenv` without path provided, zx will load from `${process.cwd()}/.env`.
+
 #### `quiet()`
 
 Changes behavior of `$` to disable verbose output.

--- a/index.mjs
+++ b/index.mjs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {config} from 'dotenv'
 import fs from 'fs-extra'
 import * as globbyModule from 'globby'
 import os from 'os'
@@ -140,6 +141,13 @@ if (typeof argv.shell === 'string') {
 }
 if (typeof argv.prefix === 'string') {
   $.prefix = argv.prefix
+}
+if (argv.dotenv) {
+  let dotenvFile = '.env';
+  if (typeof argv.dotenv === 'string') {
+    dotenvFile = argv.dotenv;
+  }
+  config({path: path.resolve(process.cwd(), dotenvFile)});
 }
 $.quote = quote
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/minimist": "^1.2.2",
     "@types/node": "^17.0",
     "chalk": "^5.0.0",
+    "dotenv": "^16.0.0",
     "fs-extra": "^10.0.1",
     "globby": "^13.1.1",
     "minimist": "^1.2.5",

--- a/zx.mjs
+++ b/zx.mjs
@@ -199,6 +199,7 @@ function printUsage() {
    zx [options] <script>
  
  Options:
+   --dotenv=<path>    : path to envfile to load (default: .env)
    --quiet            : don't echo commands
    --shell=<path>     : custom shell binary
    --prefix=<command> : prefix all commands


### PR DESCRIPTION
Not sure if you desire to have this inbuilt, but to me its pretty much essential to preload env files before running commands. I'm sure others would welcome this.

### Feature
Add an argument to load .env files prior to running the script. 

### Issues
- https://github.com/google/zx/issues/119

### NPM packages people seemed to publish to add this feature
- https://www.npmjs.com/package/zxe

### Done
- [x] Tests pass
- [x] Appropriate changes to README are included in PR