### PR TITLE
feat: provide configurable `spawn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,10 @@ $.shell = '/usr/bin/bash'
 
 Or use a CLI argument: `--shell=/bin/bash`
 
+#### `$.spanw`
+
+Specifies a `spawn` api. Defaults to `require('child_process').spawn`.
+
 #### `$.prefix`
 
 Specifies the command that will be prefixed to all commands run.

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ChildProcess} from 'child_process'
+import {ChildProcess, spawn} from 'child_process'
 import {Readable, Writable} from 'stream'
 import * as _fs from 'fs-extra'
 import * as _globby from 'globby'
@@ -30,6 +30,7 @@ interface $ {
   shell: string
   prefix: string
   quote: (input: string) => string
+  spawn: typeof spawn
 }
 
 export interface ProcessPromise<T> extends Promise<T> {

--- a/index.mjs
+++ b/index.mjs
@@ -80,7 +80,7 @@ export function $(pieces, ...args) {
       printCmd(cmd)
     }
 
-    let child = spawn(prefix + cmd, {
+    let child = $.spawn(prefix + cmd, {
       cwd: process.cwd(),
       shell: typeof shell === 'string' ? shell : true,
       stdio: [promise._inheritStdin ? 'inherit' : 'pipe', 'pipe', 'pipe'],
@@ -142,6 +142,7 @@ if (typeof argv.prefix === 'string') {
   $.prefix = argv.prefix
 }
 $.quote = quote
+$.spawn = spawn
 
 export function cd(path) {
   if ($.verbose) console.log('$', colorize(`cd ${path}`))


### PR DESCRIPTION
* Mocking and testing: ESM mocking is not handy, so if we'd like to override `cp.spawn` we have to create a new VM context with clean module cache, read files, parse them to build proper virtual refs, evaluate, etc, etc. Let's just don't.

* Debug and audit. For example, we can easily wrap the default impl and capture all internal cmd invocations of script to some file.

- [x] Appropriate changes to README are included in PR