### PR TITLE
feat: configurable `maxBuffer` spawn option

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,10 +316,6 @@ Or use a CLI argument: `--shell=/bin/bash`
 
 Specifies a `spawn` api. Defaults to `require('child_process').spawn`.
 
-#### `$.timeout`
-
-Sets a timeout for all internal spawn calls. Defaults to `undefined`.
-
 #### `$.maxBuffer`
 
 Specifies the largest number of bytes allowed on stdout or stderr.

--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ Or use a CLI argument: `--shell=/bin/bash`
 #### `$.spawn`
 
 Specifies a `spawn` api. Defaults to `require('child_process').spawn`.
+You may also assign `spawn.timeout`, `spawn.maxBuffer` and `spawn.killSignal`
+to override the default spawn options for all calls.
 
 #### `$.prefix`
 

--- a/README.md
+++ b/README.md
@@ -315,8 +315,15 @@ Or use a CLI argument: `--shell=/bin/bash`
 #### `$.spawn`
 
 Specifies a `spawn` api. Defaults to `require('child_process').spawn`.
-You may also assign `spawn.timeout`, `spawn.maxBuffer` and `spawn.killSignal`
-to override the default spawn options for all calls.
+
+#### `$.timeout`
+
+Sets a timeout for all internal spawn calls. Defaults to `undefined`.
+
+#### `$.maxBuffer`
+
+Specifies the largest number of bytes allowed on stdout or stderr.
+Defaults to `200 * 1024 * 1024` (200 MiB).
 
 #### `$.prefix`
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ChildProcess, spawn, SpawnOptions} from 'child_process'
+import {ChildProcess, spawn} from 'child_process'
 import {Readable, Writable} from 'stream'
 import * as _fs from 'fs-extra'
 import * as _globby from 'globby'
@@ -32,7 +32,6 @@ interface $ {
   quote: (input: string) => string
   spawn: typeof spawn
   maxBuffer?: number | undefined
-  timeout?: SpawnOptions['timeout']
 }
 
 export interface ProcessPromise<T> extends Promise<T> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ChildProcess, spawn} from 'child_process'
+import {ChildProcess, spawn, SpawnOptions} from 'child_process'
 import {Readable, Writable} from 'stream'
 import * as _fs from 'fs-extra'
 import * as _globby from 'globby'
@@ -30,7 +30,11 @@ interface $ {
   shell: string
   prefix: string
   quote: (input: string) => string
-  spawn: typeof spawn
+  spawn: typeof spawn & {
+    maxBuffer?: number | undefined
+    timeout?: SpawnOptions['timeout']
+    killSignal?: SpawnOptions['killSignal']
+  }
 }
 
 export interface ProcessPromise<T> extends Promise<T> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,11 +30,9 @@ interface $ {
   shell: string
   prefix: string
   quote: (input: string) => string
-  spawn: typeof spawn & {
-    maxBuffer?: number | undefined
-    timeout?: SpawnOptions['timeout']
-    killSignal?: SpawnOptions['killSignal']
-  }
+  spawn: typeof spawn
+  maxBuffer?: number | undefined
+  timeout?: SpawnOptions['timeout']
 }
 
 export interface ProcessPromise<T> extends Promise<T> {

--- a/index.mjs
+++ b/index.mjs
@@ -56,8 +56,7 @@ export function registerGlobals() {
 }
 
 export function $(pieces, ...args) {
-  let {verbose, shell, prefix, spawn} = $
-  let {timeout, killSignal, maxBuffer = 200 * 1024 * 1024 /* 200 MiB*/} = spawn
+  let {verbose, shell, prefix, spawn, timeout, maxBuffer = 200 * 1024 * 1024 /* 200 MiB*/} = $
   let __from = (new Error().stack.split(/^\s*at\s/m)[2]).trim()
 
   let cmd = pieces[0], i = 0
@@ -90,7 +89,7 @@ export function $(pieces, ...args) {
     })
 
     if (timeout) {
-      promise._timeout = setTimeout(() => promise.kill(killSignal), timeout)
+      promise._timeout = setTimeout(() => promise.kill(), timeout)
     }
 
     child.on('close', (code, signal) => {

--- a/index.mjs
+++ b/index.mjs
@@ -56,7 +56,7 @@ export function registerGlobals() {
 }
 
 export function $(pieces, ...args) {
-  let {verbose, shell, prefix, spawn, timeout, maxBuffer = 200 * 1024 * 1024 /* 200 MiB*/} = $
+  let {verbose, shell, prefix, spawn, maxBuffer = 200 * 1024 * 1024 /* 200 MiB*/} = $
   let __from = (new Error().stack.split(/^\s*at\s/m)[2]).trim()
 
   let cmd = pieces[0], i = 0
@@ -88,12 +88,7 @@ export function $(pieces, ...args) {
       maxBuffer,
     })
 
-    if (timeout) {
-      promise._timeout = setTimeout(() => promise.kill(), timeout)
-    }
-
     child.on('close', (code, signal) => {
-      promise._timeout && clearTimeout(promise._timeout)
       let message = `${stderr || '\n'}    at ${__from}`
       message += `\n    exit code: ${code}${exitCodeInfo(code) ? ' (' + exitCodeInfo(code) + ')' : ''}`
       if (signal !== null) {

--- a/test.mjs
+++ b/test.mjs
@@ -251,18 +251,6 @@ if (test('Retry works')) {
   assert(Date.now() >= now + 50 * (5 - 1))
 }
 
-if (test('spawn timeout')) {
-  let signal = 0
-  $.timeout = 100
-  try {
-    await $`sleep 9999`
-  } catch (p) {
-    signal = p.signal
-  }
-  delete $.timeout
-  assert.equal(signal, 'SIGTERM')
-}
-
 let version
 if (test('require() is working in ESM')) {
   let data = require('./package.json')

--- a/test.mjs
+++ b/test.mjs
@@ -253,16 +253,14 @@ if (test('Retry works')) {
 
 if (test('spawn timeout')) {
   let signal = 0
-  $.spawn.timeout = 100
-  $.spawn.killSignal = 'SIGKILL'
+  $.timeout = 100
   try {
     await $`sleep 9999`
   } catch (p) {
     signal = p.signal
   }
-  delete $.spawn.timeout
-  delete $.spawn.killSignal
-  assert.equal(signal, 'SIGKILL')
+  delete $.timeout
+  assert.equal(signal, 'SIGTERM')
 }
 
 let version

--- a/test.mjs
+++ b/test.mjs
@@ -251,6 +251,20 @@ if (test('Retry works')) {
   assert(Date.now() >= now + 50 * (5 - 1))
 }
 
+if (test('spawn timeout')) {
+  let signal = 0
+  $.spawn.timeout = 100
+  $.spawn.killSignal = 'SIGKILL'
+  try {
+    await $`sleep 9999`
+  } catch (p) {
+    signal = p.signal
+  }
+  delete $.spawn.timeout
+  delete $.spawn.killSignal
+  assert.equal(signal, 'SIGKILL')
+}
+
 let version
 if (test('require() is working in ESM')) {
   let data = require('./package.json')


### PR DESCRIPTION
**Maintainer**: 200 Mb is enough for stdout. No one will use `zx` to test ELK, spark and kuber orchestration.
**QIWI**: Hold my beer )

- [x] Tests pass
- [x] Appropriate changes to README are included in PR