### PR TITLE
feat: print zx version in semver-compatible format

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": "./index.mjs",
     "./globals": "./globals.mjs",
-    "./experimental": "./experimental.mjs"
+    "./experimental": "./experimental.mjs",
+    "./package.json": "./package.json"
   },
   "types": "index.d.ts",
   "bin": {

--- a/test.mjs
+++ b/test.mjs
@@ -256,6 +256,7 @@ if (test('require() is working in ESM')) {
   let data = require('./package.json')
   version = data.version
   assert.equal(data.name, 'zx')
+  assert.equal(data, require('zx/package.json'))
 }
 
 console.log('\n' +

--- a/zx.mjs
+++ b/zx.mjs
@@ -25,8 +25,8 @@ import {fetch, ProcessOutput} from './index.mjs'
 
 await async function main() {
   try {
-    if (['--version', '-v', '-V'].includes(process.argv[2] || '')) {
-      console.log(`zx version ${createRequire(import.meta.url)('./package.json').version}`)
+    if (['--version', '-v', '-V'].includes(process.argv[2])) {
+      console.log(createRequire(import.meta.url)('./package.json').version)
       return process.exitCode = 0
     }
     let firstArg = process.argv.slice(2).find(a => !a.startsWith('--'))
@@ -202,5 +202,6 @@ function printUsage() {
    --quiet            : don't echo commands
    --shell=<path>     : custom shell binary
    --prefix=<command> : prefix all commands
+   --version, -v      : print current zx version
 `)
 }


### PR DESCRIPTION
The common case is to assert the util version before running. So let's print zx version as semver-compatible string (`x.x.x` or `vx.x.x`) like the most js utils do.

```
node --version
v16.14.0 // ok
npm -v
8.5.4 // ok
git --version
git version 2.35.1 // not ok
```