### PR TITLE
Auto publish a CommonJS version as `zx-cjs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ gives sensible defaults.
 
 ## Install
 
+
 ```bash
 npm i -g zx
 ```
+
+In case you need CJS support,
+install `zx-cjs` instead.
 
 **Requirement**: Node version >= 16.0.0
 


### PR DESCRIPTION
Hello,

I pretty love this project. Unfortunately, most of the scenarios that are susceptible to use it are not ready to use an ESM library.

I setup a GitHub Actions that is triggered under zx release. It compiles the release from ESM to CJS, and publish it as [zx-cjs](https://github.com/Kikobeats/zx-cjs) into the npm registry. In this way, users can still use the latest zx version, that usually comes with new stuff to play.

I wanted to warn users about that just adding some mention into the README, since I found issues concerning about that, and I totally understand it isn't an interesting thing from a point of view of maintenance.

In this way, maintainers of zx don't need to worrying with deal with another build system since it works in auto mode, and more people can adopt zx as part of their workflow

--

If you like the idea, I will be happy to give you zx-cjs permissions over npm registry!