### PR TITLE
Changing sleep function to a synchronous blocking function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ type QuestionOptions = { choices: string[] }
 
 #### `sleep()`
 
-A wrapper around the `setTimeout` function.
+Blocks Node for a specified timeout.
 
 ```js
-await sleep(1000)
+sleep(1000)
 ```
 
 #### `nothrow()`

--- a/experimental.mjs
+++ b/experimental.mjs
@@ -21,7 +21,7 @@ export const retry = (count = 5, delay = 0) => async (cmd, ...args) => {
     return await $(cmd, ...args)
   } catch (p) {
     if (count === 0) throw p
-    if (delay) await sleep(delay)
+    if (delay) sleep(delay)
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,7 +60,7 @@ export type QuestionOptions = { choices: string[] }
 type cd = (path: string) => void
 type nothrow = (p: ProcessPromise<ProcessOutput>) => ProcessPromise<ProcessOutput>
 type question = (query?: string, options?: QuestionOptions) => Promise<string>
-type sleep = (ms: number) => Promise<void>
+type sleep = (ms: number) => void
 type quiet = (p: ProcessPromise<ProcessOutput>) => ProcessPromise<ProcessOutput>
 
 export const $: $

--- a/index.mjs
+++ b/index.mjs
@@ -27,7 +27,12 @@ import minimist from 'minimist'
 import psTreeModule from 'ps-tree'
 
 export {chalk, fs, os, path, YAML}
-export const sleep = promisify(setTimeout)
+export const sleep = (delay) => {
+  const timeout = Date.now() + delay;
+  while(1){
+    if( Date.now() == timeout ) break;
+  }
+} // blocking the event loop.
 export const argv = minimist(process.argv.slice(2))
 export const globby = Object.assign(function globby(...args) {
   return globbyModule.globby(...args)

--- a/index.mjs
+++ b/index.mjs
@@ -28,10 +28,13 @@ import psTreeModule from 'ps-tree'
 
 export {chalk, fs, os, path, YAML}
 export const sleep = (delay) => {
-  const timeout = Date.now() + delay;
+  if(+delay){ 
+  const timeout = Date.now() + +delay;
   while(1){
     if( Date.now() == timeout ) break;
+    }
   }
+  return;
 } // blocking the event loop.
 export const argv = minimist(process.argv.slice(2))
 export const globby = Object.assign(function globby(...args) {


### PR DESCRIPTION
Fixes Sleep behaviour.

Sleep as a setTimeout Wrapper doesnt really stop the event loop from executing earlier scheduled callbacks.
in the example of running a timedout timer before `sleep`, the timer's handle callback will be executed and the sleep behavior will be delayed by the callback's execution time.
So starting a `loop`, synchronous task in the polling phase, will prevent the misbehavior of the event loop due to the asynchronous sleep function.

- [ 27 ] Tests pass.
- [ Sleep definition ] Changes to README.