### PR TITLE
feat: load experimental assets as globals via `--experimental` flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 package-lock.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ let {version} = require('./package.json')
 
 The zx also provides a few experimental functions. Please leave a feedback about 
 those features in [the discussion](https://github.com/google/zx/discussions/299).
+To enable new features via CLI pass `--experimantal` flag.
 
 #### `retry()`
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ let {version} = require('./package.json')
 
 The zx also provides a few experimental functions. Please leave a feedback about 
 those features in [the discussion](https://github.com/google/zx/discussions/299).
-To enable new features via CLI pass `--experimantal` flag.
+To enable new features via CLI pass `--experimental` flag.
 
 #### `retry()`
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -130,6 +130,11 @@ $.quote = quote
 $.spawn = spawn
 $.verbose = true
 $.prefix = '' // Bash not found, no prefix.
+try {
+  $.shell = which.sync('bash')
+  $.prefix = 'set -euo pipefail;'
+} catch (e) {
+}
 
 export function cd(path) {
   if ($.verbose) console.log('$', colorize(`cd ${path}`))

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -126,23 +126,10 @@ export function $(pieces, ...args) {
   return promise
 }
 
-$.verbose = !argv.quiet
-if (typeof argv.shell === 'string') {
-  $.shell = argv.shell
-  $.prefix = ''
-} else {
-  try {
-    $.shell = which.sync('bash')
-    $.prefix = 'set -euo pipefail;'
-  } catch (e) {
-    $.prefix = '' // Bash not found, no prefix.
-  }
-}
-if (typeof argv.prefix === 'string') {
-  $.prefix = argv.prefix
-}
 $.quote = quote
 $.spawn = spawn
+$.verbose = true
+$.prefix = '' // Bash not found, no prefix.
 
 export function cd(path) {
   if ($.verbose) console.log('$', colorize(`cd ${path}`))

--- a/zx.mjs
+++ b/zx.mjs
@@ -20,10 +20,27 @@ import {tmpdir} from 'os'
 import {basename, dirname, extname, join, resolve} from 'path'
 import url from 'url'
 
-import './src/globals.mjs'
-import {fetch, ProcessOutput} from './src/index.mjs'
+import {$, argv, fetch, ProcessOutput, registerGlobals} from './src/index.mjs'
+import which from 'which'
 
 await async function main() {
+  registerGlobals()
+  $.verbose = !argv.quiet
+  if (typeof argv.shell === 'string') {
+    $.shell = argv.shell
+  } else {
+    try {
+      $.shell = which.sync('bash')
+      $.prefix = 'set -euo pipefail;'
+    } catch (e) {
+    }
+  }
+  if (typeof argv.prefix === 'string') {
+    $.prefix = argv.prefix
+  }
+  if (argv.experimental) {
+    Object.assign(global, await import('./src/experimental.mjs'))
+  }
   try {
     if (['--version', '-v', '-V'].includes(process.argv[2])) {
       console.log(createRequire(import.meta.url)('./package.json').version)
@@ -197,7 +214,7 @@ function printUsage() {
 
  Usage:
    zx [options] <script>
- 
+
  Options:
    --quiet            : don't echo commands
    --shell=<path>     : custom shell binary

--- a/zx.mjs
+++ b/zx.mjs
@@ -213,6 +213,7 @@ function printUsage() {
    --quiet            : don't echo commands
    --shell=<path>     : custom shell binary
    --prefix=<command> : prefix all commands
+   --experimental     : enable new api proposals
    --version, -v      : print current zx version
 `)
 }

--- a/zx.mjs
+++ b/zx.mjs
@@ -28,12 +28,6 @@ await async function main() {
   $.verbose = !argv.quiet
   if (typeof argv.shell === 'string') {
     $.shell = argv.shell
-  } else {
-    try {
-      $.shell = which.sync('bash')
-      $.prefix = 'set -euo pipefail;'
-    } catch (e) {
-    }
   }
   if (typeof argv.prefix === 'string') {
     $.prefix = argv.prefix


### PR DESCRIPTION
- [x] Appropriate changes to README are included in PR