### PR TITLE
fix: bind cwd to spawn call

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -58,6 +58,7 @@ export function registerGlobals() {
 export function $(pieces, ...args) {
   let {verbose, shell, prefix, spawn, maxBuffer = 200 * 1024 * 1024 /* 200 MiB*/} = $
   let __from = (new Error().stack.split(/^\s*at\s/m)[2]).trim()
+  let cwd = process.cwd()
 
   let cmd = pieces[0], i = 0
   while (i < args.length) {
@@ -81,7 +82,7 @@ export function $(pieces, ...args) {
     }
 
     let child = spawn(prefix + cmd, {
-      cwd: process.cwd(),
+      cwd,
       shell: typeof shell === 'string' ? shell : true,
       stdio: [promise._inheritStdin ? 'inherit' : 'pipe', 'pipe', 'pipe'],
       windowsHide: true,

--- a/test.mjs
+++ b/test.mjs
@@ -204,10 +204,16 @@ if (test('The cd() works with relative paths')) {
   try {
     fs.mkdirpSync('/tmp/zx-cd-test/one/two')
     cd('/tmp/zx-cd-test/one/two')
+    let p1 = $`pwd`
     cd('..')
+    let p2 = $`pwd`
     cd('..')
-    let pwd = (await $`pwd`).stdout.trim()
-    assert.equal(path.basename(pwd), 'zx-cd-test')
+    let p3 = $`pwd`
+
+    let results = (await Promise.all([p1, p2, p3]))
+      .map(p => path.basename(p.stdout.trim()))
+
+    assert.deepEqual(results, ['two', 'one', 'zx-cd-test'])
   } finally {
     fs.rmSync('/tmp/zx-cd-test', {recursive: true})
     cd(__dirname)


### PR DESCRIPTION
`cwd` should not mutate inside $ call.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR