### PR TITLE
refactor: simplify echo helper, add tests for experimental features

### DIFF
--- a/src/experimental.mjs
+++ b/src/experimental.mjs
@@ -37,19 +37,13 @@ export const withTimeout = (timeout, signal) => async (cmd, ...args) => {
 
 // A console.log() alternative which can take ProcessOutput.
 export function echo(pieces, ...args) {
+  let msg
   if (Array.isArray(pieces) && pieces.every(isString) && pieces.length - 1 === args.length) {
-    let msg = pieces[0], i = 0
-    while (i < args.length) {
-      msg += stringify(args[i]) + pieces[++i]
-    }
-    console.log(msg)
+    msg = args.map((a, i) => pieces.at(i) + stringify(a)).join('') + pieces.at(-1)
   } else {
-    let msg = []
-    for (let it of [pieces, ...args]) {
-      msg.push(it instanceof ProcessOutput ? stringify(it) : it)
-    }
-    console.log(...msg)
+    msg = [pieces, ...args].map(stringify).join(' ')
   }
+  console.log(msg)
 }
 
 function isString(obj) {

--- a/src/experimental.mjs
+++ b/src/experimental.mjs
@@ -38,8 +38,9 @@ export const withTimeout = (timeout, signal) => async (cmd, ...args) => {
 // A console.log() alternative which can take ProcessOutput.
 export function echo(pieces, ...args) {
   let msg
-  if (Array.isArray(pieces) && pieces.every(isString) && pieces.length - 1 === args.length) {
-    msg = args.map((a, i) => pieces.at(i) + stringify(a)).join('') + pieces.at(-1)
+  let lastIdx = pieces.length - 1
+  if (Array.isArray(pieces) && pieces.every(isString) && lastIdx === args.length) {
+    msg = args.map((a, i) => pieces[i] + stringify(a)).join('') + pieces[lastIdx]
   } else {
     msg = [pieces, ...args].map(stringify).join(' ')
   }

--- a/test.mjs
+++ b/test.mjs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {strict as assert} from 'assert'
-import {retry, withTimeout} from './src/experimental.mjs'
+import {retry, echo, startSpinner, withTimeout } from './src/experimental.mjs'
 
 let всегоТестов = 0
 
@@ -249,7 +249,7 @@ if (test('which available')) {
   assert.equal(which.sync('npm'), await which('npm'))
 }
 
-if (test('Retry works')) {
+if (test('Retry works (experimental)')) {
   let exitCode = 0
   let now = Date.now()
   try {
@@ -261,17 +261,30 @@ if (test('Retry works')) {
   assert(Date.now() >= now + 50 * (5 - 1))
 }
 
-if (test('withTimeout works')) {
-  let exitCode = 0
-  let signal
-  try {
-    await withTimeout(100, 'SIGKILL')`sleep 9999`
-  } catch (p) {
-    exitCode = p.exitCode
-    signal = p.signal
-  }
-  assert.equal(exitCode, null)
-  assert.equal(signal, 'SIGKILL')
+if (test('withTimeout works (experimental)')) {
+    let exitCode = 0
+    let signal
+    try {
+      await withTimeout(100, 'SIGKILL')`sleep 9999`
+    } catch (p) {
+      exitCode = p.exitCode
+      signal = p.signal
+    }
+    // assert.equal(exitCode, null)
+    assert.equal(signal, 'SIGKILL')
+}
+
+if (test('echo works (experimental)')) {
+  echo(chalk.red('foo'), chalk.green('bar'), chalk.bold('baz'))
+  echo`${chalk.red('foo')} ${chalk.green('bar')} ${chalk.bold('baz')}`
+  echo(await $`echo ${chalk.red('foo')}`, await $`echo ${chalk.green('bar')}`, await $`echo ${chalk.bold('baz')}`)
+}
+
+if (test('spinner works (experimental)')) {
+  let s = startSpinner('waiting')
+
+  await sleep(1000)
+  s()
 }
 
 let version

--- a/test.mjs
+++ b/test.mjs
@@ -262,16 +262,16 @@ if (test('Retry works (experimental)')) {
 }
 
 if (test('withTimeout works (experimental)')) {
-    let exitCode = 0
-    let signal
-    try {
-      await withTimeout(100, 'SIGKILL')`sleep 9999`
-    } catch (p) {
-      exitCode = p.exitCode
-      signal = p.signal
-    }
-    // assert.equal(exitCode, null)
-    assert.equal(signal, 'SIGKILL')
+  let exitCode = 0
+  let signal
+  try {
+    await withTimeout(100, 'SIGKILL')`sleep 9999`
+  } catch (p) {
+    exitCode = p.exitCode
+    signal = p.signal
+  }
+  assert.equal(exitCode, null)
+  assert.equal(signal, 'SIGKILL')
 }
 
 if (test('echo works (experimental)')) {

--- a/zx.mjs
+++ b/zx.mjs
@@ -21,7 +21,6 @@ import {basename, dirname, extname, join, resolve} from 'path'
 import url from 'url'
 
 import {$, argv, fetch, ProcessOutput, registerGlobals} from './src/index.mjs'
-import which from 'which'
 
 await async function main() {
   registerGlobals()


### PR DESCRIPTION
util `stringify` has its own `instanceof ProcessOutput` check, so it can be removed from `echo`

- [x] Tests pass