### PR TITLE
fix: do not rely on globals inside `experimental.mjs`

### DIFF
--- a/src/experimental.mjs
+++ b/src/experimental.mjs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ProcessOutput} from './index.mjs'
+import {ProcessOutput, sleep, $} from './index.mjs'
 
 // Retries a command a few times. Will return after the first
 // successful attempt, or will throw after specifies attempts count.


### PR DESCRIPTION
```
npm % node src/main/js/index.mjs --lockfile=../../yarn.lock --temp=../../tempy
file:///Users/antongolub/projects/sros/node_modules/zx/src/experimental.mjs:24
    if (delay) await sleep(delay)
               ^

ReferenceError: sleep is not defined
```
