### PR TITLE
fix: ts type redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "A tool for writing better scripts.",
   "main": "src/index.mjs",
   "types": "src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./src/*",
+        "./src/index.d.ts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "import": "./src/index.mjs",


### PR DESCRIPTION

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
- [x] Types updated

if `import 'zx/globals'`, typescript by default only find the `zx/globals.d.ts` file, not the `types: "./src/*"` specified in the `package.json#exports` .

<img width="346" alt="image" src="https://user-images.githubusercontent.com/59400654/160377223-9fa74496-b6e5-4c8f-89b8-6762ba951053.png">


so, need use `typesVersions` redirect types file position

<img width="395" alt="image" src="https://user-images.githubusercontent.com/59400654/160377681-5294c4c2-674f-4e85-9ea8-da7ec392822c.png">


refer [typesVersions](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions)

