### PR TITLE
feat: hideCmd modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,21 @@ await quiet($`grep something from-file`)
 // Command and output will not be displayed.
 ```
 
+#### `hideCmd()`
+
+Changes behavior of `$` to disable printing the command.
+
+```ts
+function hideCmd<P>(p: P): P
+```
+
+Usage:
+
+```js
+await hideCmd($`grep something from-file`)
+// Command will not be displayed.
+```
+
 ### Packages
 
 Following packages are available without importing inside scripts.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -65,6 +65,7 @@ type nothrow = (p: ProcessPromise<ProcessOutput>) => ProcessPromise<ProcessOutpu
 type question = (query?: string, options?: QuestionOptions) => Promise<string>
 type sleep = (ms: number) => Promise<void>
 type quiet = (p: ProcessPromise<ProcessOutput>) => ProcessPromise<ProcessOutput>
+type output = (p: ProcessPromise<ProcessOutput>) => ProcessPromise<ProcessOutput>
 
 export const $: $
 export const argv: ParsedArgs

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -65,7 +65,7 @@ type nothrow = (p: ProcessPromise<ProcessOutput>) => ProcessPromise<ProcessOutpu
 type question = (query?: string, options?: QuestionOptions) => Promise<string>
 type sleep = (ms: number) => Promise<void>
 type quiet = (p: ProcessPromise<ProcessOutput>) => ProcessPromise<ProcessOutput>
-type output = (p: ProcessPromise<ProcessOutput>) => ProcessPromise<ProcessOutput>
+type hideCmd = (p: ProcessPromise<ProcessOutput>) => ProcessPromise<ProcessOutput>
 
 export const $: $
 export const argv: ParsedArgs

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -47,6 +47,7 @@ export function registerGlobals() {
     globby,
     nothrow,
     quiet,
+    hideCmd,
     os,
     path,
     question,
@@ -78,7 +79,7 @@ export function $(pieces, ...args) {
   promise._run = () => {
     if (promise.child) return // The _run() called from two places: then() and setTimeout().
     if (promise._prerun) promise._prerun() // In case $1.pipe($2), the $2 returned, and on $2._run() invoke $1._run().
-    if (verbose && !promise._quiet) {
+    if (verbose && !promise._quiet && !promise._hideCmd) {
       printCmd(cmd)
     }
 
@@ -183,6 +184,11 @@ export function nothrow(promise) {
 
 export function quiet(promise) {
   promise._quiet = true
+  return promise
+}
+
+export function hideCmd(promise) {
+  promise._hideCmd = true
   return promise
 }
 

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -96,6 +96,15 @@ if (test('Quiet mode is working')) {
   assert(!stdout.includes('echo'))
 }
 
+if (test('hideCmd is working')) {
+  let stdout = ''
+  let log = console.log
+  console.log = (...args) => {stdout += args.join(' ')}
+  await hideCmd($`echo 'test'`)
+  console.log = log
+  assert(!stdout.includes('echo'))
+}
+
 if (test('Pipes are working')) {
   let {stdout} = await $`echo "hello"`
     .pipe($`awk '{print $1" world"}'`)


### PR DESCRIPTION
This implements a `hideCmd` modifier to avoid printing the command.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
- [x] Types updated
