### PR TITLE
Configurable / overridable log, default stderr

### DIFF
--- a/src/experimental.mjs
+++ b/src/experimental.mjs
@@ -35,7 +35,7 @@ export const withTimeout = (timeout, signal) => async (cmd, ...args) => {
   return p.finally(() => clearTimeout(timer))
 }
 
-// A console.log() alternative which can take ProcessOutput.
+// A $.log() alternative which can take ProcessOutput.
 export function echo(pieces, ...args) {
   let msg
   let lastIdx = pieces.length - 1
@@ -44,7 +44,7 @@ export function echo(pieces, ...args) {
   } else {
     msg = [pieces, ...args].map(stringify).join(' ')
   }
-  console.log(msg)
+  $.log(msg)
 }
 
 function isString(obj) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -139,7 +139,7 @@ try {
 }
 
 export function cd(path) {
-  if ($.verbose) console.log('$', colorize(`cd ${path}`))
+  if ($.verbose) $.log('$', colorize(`cd ${path}`))
   process.chdir(path)
 }
 
@@ -168,9 +168,9 @@ export async function question(query, options) {
 export async function fetch(url, init) {
   if ($.verbose) {
     if (typeof init !== 'undefined') {
-      console.log('$', colorize(`fetch ${url}`), init)
+      $.log('$', colorize(`fetch ${url}`), init)
     } else {
-      console.log('$', colorize(`fetch ${url}`))
+      $.log('$', colorize(`fetch ${url}`))
     }
   }
   return nodeFetch(url, init)
@@ -309,12 +309,12 @@ export class ProcessOutput extends Error {
 
 function printCmd(cmd) {
   if (/\n/.test(cmd)) {
-    console.log(cmd
+    $.log(cmd
       .split('\n')
       .map((line, i) => (i === 0 ? '$' : '>') + ' ' + colorize(line))
       .join('\n'))
   } else {
-    console.log('$', colorize(cmd))
+    $.log('$', colorize(cmd))
   }
 }
 

--- a/test/zx.test.mjs
+++ b/test/zx.test.mjs
@@ -31,13 +31,24 @@ if (test('prints help')) {
   assert(help.includes('print current zx version'))
 }
 
+if (test('logs to stderr by default')) {
+  let p = await $`node zx.mjs docs/markdown.md`
+  assert(!p.stdout.includes('whoami') && p.stdout.includes('docs/markdown'))
+  assert(p.stderr.includes('whoami') && !p.stderr.includes('docs/markdown'))
+}
+
 if (test('supports `--experimental` flag')) {
   await $`echo 'echo("test")' | node zx.mjs --experimental`
 }
 
 if (test('supports `--quiet` flag / Quiet mode is working')) {
   let p = await $`node zx.mjs --quiet docs/markdown.md`
-  assert(!p.stdout.includes('whoami'))
+  assert(!(p.stderr + ' ' + p.stdout).includes('whoami'))
+}
+
+if (test('supports `--log-stdout` flag / Standard out logging mode is working')) {
+  let p = await $`node zx.mjs --log-stdout docs/markdown.md`
+  assert(p.stdout.includes('whoami') && !p.stderr.includes('whomai'))
 }
 
 if (test('supports `--shell` flag ')) {

--- a/zx.mjs
+++ b/zx.mjs
@@ -31,12 +31,13 @@ await async function main() {
   if (typeof argv.prefix === 'string') {
     $.prefix = argv.prefix
   }
+  $.log = argv['log-stdout'] ? (...args) => console.log(...args) : (...args) => console.error(...args)
   if (argv.experimental) {
     Object.assign(global, await import('./src/experimental.mjs'))
   }
   try {
     if (['--version', '-v', '-V'].includes(process.argv[2])) {
-      console.log(createRequire(import.meta.url)('./package.json').version)
+      $.log(createRequire(import.meta.url)('./package.json').version)
       return process.exitCode = 0
     }
     let firstArg = process.argv.slice(2).find(a => !a.startsWith('--'))
@@ -202,7 +203,7 @@ function transformMarkdown(source) {
 }
 
 function printUsage() {
-  console.log(`
+  $.log(`
  ${chalk.bgGreenBright.black(' ZX ')}
 
  Usage:
@@ -212,6 +213,7 @@ function printUsage() {
    --quiet            : don't echo commands
    --shell=<path>     : custom shell binary
    --prefix=<command> : prefix all commands
+   --log-stdout       : logging / echo to stdout (default stderr)
    --experimental     : enable new api proposals
    --version, -v      : print current zx version
 `)


### PR DESCRIPTION
Change diagnostic / feedback / logging statements to a `$.log()` function (instead of hardcoding `console.log()`, thus this could be overridden by scripts as well.

Default existing zx diagnostic info messages (like echoing commands) to stderr (so piping works / behaves like other CLI tools, even in verbose mode, and aligns with [POSIX standard of "diagnostic" vs "conventional output"](https://pubs.opengroup.org/onlinepubs/9699919799/functions/stderr.html), more links / discussion in issue #375), and myriad cli tools that print diagnostic info / verbose logging to stderr.

Add zx CLI arg `--log-stdout` to instead send diagnostics to stdout, if desired.

Fixes #375

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
- [x] Types updated
