### PR TITLE
Add npm prompts package for command line prompts support with good interactivity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules/
+node_modules
 package-lock.json
 yarn.lock
 coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /node_modules/
-node_modules
 package-lock.json
 yarn.lock
 coverage

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "globby": "^13.1.1",
     "minimist": "^1.2.5",
     "node-fetch": "^3.2.3",
+    "prompts": "^2.4.2",
     "ps-tree": "^1.2.0",
     "which": "^2.0.2",
     "yaml": "^1.10.2"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,11 +1,11 @@
 // Copyright 2021 Google LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@ import * as _yaml from 'yaml'
 import _fetch from 'node-fetch'
 import {ParsedArgs} from 'minimist'
 import * as _which from 'which'
+import * as _prompts from 'prompts'
 
 export interface ZxTemplate {
   (pieces: TemplateStringsArray, ...args: any[]): ProcessPromise<ProcessOutput>
@@ -82,3 +83,4 @@ export const question: question
 export const sleep: sleep
 export const quiet: quiet
 export const which: typeof _which
+export const prompts: typeof _prompts

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,11 +1,11 @@
 // Copyright 2021 Google LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,8 +25,10 @@ import chalk from 'chalk'
 import YAML from 'yaml'
 import minimist from 'minimist'
 import psTreeModule from 'ps-tree'
+import prompts from 'prompts'
 
-export {chalk, fs, os, path, YAML, which}
+
+export {chalk, fs, os, path, YAML, which, prompts}
 export const sleep = promisify(setTimeout)
 export const argv = minimist(process.argv.slice(2))
 export const globby = Object.assign(function globby(...args) {
@@ -53,6 +55,7 @@ export function registerGlobals() {
     sleep,
     YAML,
     which,
+    prompts,
   })
 }
 


### PR DESCRIPTION
Lightweight, beautiful and user-friendly interactive prompts
>_ Easy to use CLI prompts to enquire users for information▌


Simple: prompts has [no big dependencies](http://npm.anvaka.com/#/view/2d/prompts) nor is it broken into a [dozen](http://npm.anvaka.com/#/view/2d/inquirer) tiny modules that only work well together.
User friendly: prompt uses layout and colors to create beautiful cli interfaces.
Promised: uses promises and async/await. No callback hell.
Flexible: all [prompts](https://github.com/terkelg/prompts#-types) are independent and can be used on their own.
Testable: provides a way to submit answers programmatically.
Unified: consistent experience across all prompts.
