### PR TITLE
feat: provide logger customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,16 +352,61 @@ command substitution.
 
 ### `$.verbose`
 
-Specifies verbosity. Default is `true`.
+Specifies verbosity level: `0 | 1 | 2`. Default is `2`.
 
-In verbose mode, the `zx` prints all executed commands alongside with their 
-outputs.
+In verbose mode `2`, the `zx` prints all executed commands alongside with their 
+outputs. `0` suppresses any log output.
 
-Or use a CLI argument `--quiet` to set `$.verbose = false`.
+Or use via CLI arguments:
+* `--verbose=<l>` to set `$.verbose = <l>`.
+* `--quiet` to set `$.verbose = 0`.
 
 ### `$.env`
 
 Specifies env map. Defaults to `process.env`.
+
+### `$.logOutput`
+
+Specifies zx debug channel: `stdout/stderr`. Defaults to `stderr`.
+
+### `$.logFormat`
+
+Specifies zx log output formatter. Defaults to `identity`.
+
+```js
+// Nice place to add masker, if you pass creds to zx methods
+$.logFormat = (msg) => msg.map(m => m.toUpperCase())
+```
+
+### `$.logIgnore`
+
+Specifies log events to filter out. Defaults to `''`, so everything is being logged.
+
+```js
+$.logIgnore = ['cd', 'fetch']
+cd('/tmp/foo')
+$.fetch('https://example.com')
+// `$ cd /tmp/foo` is omitted
+// `$ fetch https://example.com` is not printed too
+
+$.logIgnore = 'cmd'
+$`echo 'test'`
+// prints `test` w/o `$ echo 'test'`
+```
+
+### `$.logPrint`
+
+Specifies event logging stream. Defaults to `process.stdout/process.stderr`.
+
+```js
+let stdout = ''
+let stderr = ''
+
+$.logPrint = (data, err) => {
+  if (data) stdout += data
+  if (err) stderr += err
+}
+```
 
 ## Polyfills 
 
@@ -458,6 +503,17 @@ runInCtx({ ...getCtx() }, async () => {
   // $.cwd refers to /foo
   // but getCtx().cwd !== $.cwd
 })
+```
+
+### `log()`
+
+Internal zx logger. Accepts config via `$.log*` options.
+
+```js
+import {log} from 'zx/experimental'
+
+log({scope: 'foo', verbose: 1, output: 'stderr'}, 'some', 'data')
+// some data
 ```
 
 ## FAQ

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "chalk": "^5.0.1",
     "fs-extra": "^10.1.0",
     "globby": "^13.1.1",
+    "ignore": "^5.2.0",
     "minimist": "^1.2.6",
     "node-fetch": "^3.2.4",
     "ps-tree": "^1.2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,8 @@ import { randomId } from './util.js'
 import './globals.js'
 
 await (async function main() {
-  $.verbose = !argv.quiet
+  $.verbose = +(argv.verbose || argv.quiet ? 0 : $.verbose)
+
   if (typeof argv.shell === 'string') {
     $.shell = argv.shell
   }
@@ -220,7 +221,8 @@ function printUsage() {
    zx [options] <script>
 
  Options:
-   --quiet            : don't echo commands
+   --verbose          : verbosity level 0|1|2
+   --quiet            : don't echo commands, same as --verbose=0
    --shell=<path>     : custom shell binary
    --prefix=<command> : prefix all commands
    --experimental     : enable new api proposals

--- a/src/core.ts
+++ b/src/core.ts
@@ -24,7 +24,7 @@ import { inspect, promisify } from 'node:util'
 
 import { chalk, which } from './goods.js'
 import { runInCtx, getCtx, setRootCtx } from './context.js'
-import { log, colorize } from './log.js'
+import { log, printCmd } from './log.js'
 import { quote, substitute } from './guards.js'
 
 import psTreeModule from 'ps-tree'
@@ -314,20 +314,6 @@ export class ProcessOutput extends Error {
         : ''
     }
 }`
-  }
-}
-
-function printCmd(cmd: string) {
-  if (/\n/.test(cmd)) {
-    log(
-      { scope: 'cmd' },
-      cmd
-        .split('\n')
-        .map((line, i) => (i === 0 ? '$' : '>') + ' ' + colorize(line))
-        .join('\n')
-    )
-  } else {
-    log({ scope: 'cmd' }, '$', colorize(cmd))
   }
 }
 

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -16,8 +16,9 @@ import { ProcessOutput, $ } from './core.js'
 import { sleep } from './goods.js'
 import { isString } from './util.js'
 import { getCtx, runInCtx } from './context.js'
+import { log } from './log.js'
 
-export { getCtx, runInCtx }
+export { getCtx, runInCtx, log }
 
 // Retries a command a few times. Will return after the first
 // successful attempt, or will throw after specifies attempts count.
@@ -58,9 +59,9 @@ export function echo(pieces: TemplateStringsArray, ...args: any[]) {
     msg =
       args.map((a, i) => pieces[i] + stringify(a)).join('') + pieces[lastIdx]
   } else {
-    msg = [pieces, ...args].map(stringify).join(' ')
+    msg = [pieces, ...args].map(stringify)
   }
-  console.log(msg)
+  log({ scope: 'echo', verbose: 0 }, Array.isArray(msg) ? msg.join(' ') : msg)
 }
 
 function stringify(arg: ProcessOutput | any) {

--- a/src/goods.ts
+++ b/src/goods.ts
@@ -17,7 +17,7 @@ import minimist from 'minimist'
 import { setTimeout as sleep } from 'node:timers/promises'
 import nodeFetch, { RequestInfo, RequestInit } from 'node-fetch'
 import { getCtx, getRootCtx } from './context.js'
-import { colorize } from './print.js'
+import { colorize, log } from './log.js'
 
 export { default as chalk } from 'chalk'
 export { default as fs } from 'fs-extra'
@@ -40,18 +40,17 @@ globbyModule)
 export const glob = globby
 
 export async function fetch(url: RequestInfo, init?: RequestInit) {
-  if (getCtx().verbose) {
-    if (typeof init !== 'undefined') {
-      console.log('$', colorize(`fetch ${url}`), init)
-    } else {
-      console.log('$', colorize(`fetch ${url}`))
-    }
-  }
+  log(
+      { scope: 'fetch' },
+      '$',
+      colorize(`fetch ${url}`),
+      init && JSON.stringify(init, null, 2)
+  )
   return nodeFetch(url, init)
 }
 
 export function cd(path: string) {
-  if (getCtx().verbose) console.log('$', colorize(`cd ${path}`))
+  log({ scope: 'cd' }, '$', colorize(`cd ${path}`))
   process.chdir(path)
   getRootCtx().cwd = getCtx().cwd = process.cwd()
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -20,6 +20,6 @@ export function nothrow(promise: ProcessPromise) {
 }
 
 export function quiet(promise: ProcessPromise) {
-  promise.ctx!.verbose = false
+  promise.ctx!.verbose = 0
   return promise
 }

--- a/src/log.ts
+++ b/src/log.ts
@@ -52,7 +52,7 @@ export function log(opts: {scope: string, verbose?: 0|1|2, output?: 'stdout'|'st
   } = ctx
   let level = Math.min(+getRootCtx().verbose, +ctx.verbose)
 
-  if (verbose < level) return
+  if (verbose > level) return
 
   const ig = ignore().add(logIgnore)
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -16,20 +16,6 @@ import {getCtx, getRootCtx} from './context.js'
 import { chalk } from './goods.js'
 import { default as ignore } from 'ignore'
 
-export function printCmd(cmd: string) {
-  if (!getCtx()?.verbose) return
-  if (/\n/.test(cmd)) {
-    console.log(
-      cmd
-        .split('\n')
-        .map((line, i) => (i === 0 ? '$' : '>') + ' ' + colorize(line))
-        .join('\n')
-    )
-  } else {
-    console.log('$', colorize(cmd))
-  }
-}
-
 export function printStd(data: any, err?: any) {
   if (data) process.stdout.write(data)
   if (err) process.stderr.write(err)
@@ -59,5 +45,19 @@ export function log(opts: {scope: string, verbose?: 0|1|2, output?: 'stdout'|'st
   if (!ig.ignores(scope)) {
     msg = raw ? msg[0] : logFormat(msg)?.join(' ') + '\n'
     logPrint(...(logOutput === 'stdout' ? [msg] : [null, msg]))
+  }
+}
+
+export function printCmd(cmd: string) {
+  if (/\n/.test(cmd)) {
+    log(
+        { scope: 'cmd' },
+        cmd
+            .split('\n')
+            .map((line, i) => (i === 0 ? '$' : '>') + ' ' + colorize(line))
+            .join('\n')
+    )
+  } else {
+    log({ scope: 'cmd' }, '$', colorize(cmd))
   }
 }

--- a/src/log.ts
+++ b/src/log.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { getCtx } from './context.js'
+import {getCtx, getRootCtx} from './context.js'
 import { chalk } from './goods.js'
 import { default as ignore } from 'ignore'
 
@@ -42,16 +42,17 @@ export function colorize(cmd: string) {
 }
 
 export function log(opts: {scope: string, verbose?: 0|1|2, output?: 'stdout'|'stderr', raw?: boolean}, ...msg: any[]) {
-  let { scope, verbose: _verbose = 1, output, raw } = opts
+  let { scope, verbose = 1, output, raw } = opts
+  let ctx = getCtx()
   let {
-    verbose = 2,
     logOutput = output || 'stderr',
     logFormat = () => msg,
     logPrint = printStd,
     logIgnore,
-  } = getCtx()
+  } = ctx
+  let level = Math.min(+getRootCtx().verbose, +ctx.verbose)
 
-  if (verbose < _verbose) return
+  if (verbose < level) return
 
   const ig = ignore().add(logIgnore)
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -16,7 +16,7 @@ import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 import '../build/globals.js'
 
-$.verbose = false
+$.verbose = 0
 
 test('supports `-v` flag / prints version', async () => {
   assert.match((await $`node build/cli.js -v`).toString(), /\d+.\d+.\d+/)

--- a/test/experimental.test.js
+++ b/test/experimental.test.js
@@ -26,7 +26,7 @@ import {
   log
 } from '../build/experimental.js'
 
-$.verbose = false
+$.verbose = 0
 
 test('retry works', async () => {
   let exitCode = 0

--- a/test/experimental.test.js
+++ b/test/experimental.test.js
@@ -14,6 +14,8 @@
 
 import { test } from 'uvu'
 import * as assert from 'uvu/assert'
+
+import chalk from 'chalk'
 import '../build/globals.js'
 
 import {
@@ -21,9 +23,8 @@ import {
   retry,
   startSpinner,
   withTimeout,
+  log
 } from '../build/experimental.js'
-
-import chalk from 'chalk'
 
 $.verbose = false
 
@@ -69,6 +70,10 @@ test('spinner works', async () => {
   let s = startSpinner('waiting')
   await sleep(1000)
   s()
+})
+
+test('log() api is exported', () => {
+  assert.ok(typeof log === 'function')
 })
 
 test.run()

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -50,6 +50,8 @@ test('undefined and empty string correctly quoted', async () => {
   $.verbose = true
   assert.is((await $`echo -n ${undefined}`).toString(), 'undefined')
   assert.is((await $`echo -n ${''}`).toString(), '')
+
+  $.verbose = 0
 })
 
 test('can create a dir with a space in the name', async () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,6 +22,8 @@ import '../build/globals.js'
 import { ProcessPromise } from '../build/index.js'
 import {getCtx, runInCtx} from '../build/experimental.js'
 
+$.verbose = 0
+
 test('only stdout is used during command substitution', async () => {
   let hello = await $`echo Error >&2; echo Hello`
   let len = +(await $`echo ${hello} | wc -c`)

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -16,6 +16,8 @@ import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 import { log } from '../build/log.js'
 
+$.verbose = 0
+
 test('logger works', async () => {
   let stdout = ''
   let stderr = ''

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -1,0 +1,48 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+import { log } from '../build/log.js'
+
+test('logger works', async () => {
+  let stdout = ''
+  let stderr = ''
+  $.logFormat = (msg) => msg.map((m) => m.toUpperCase())
+  $.logPrint = (data, err) => {
+    if (data) stdout += data
+    if (err) stderr += err
+  }
+  $.logIgnore = ['b*', 'fetch']
+  log({ scope: 'foo' }, 'foo-test')
+  log({ scope: 'bar' }, 'bar-test')
+  log({ scope: 'baz' }, 'baz-test')
+  log({ scope: 'fetch' }, 'example.com')
+
+  assert.ok(stderr.includes('FOO-TEST'))
+  assert.ok(!stderr.includes('BAR-TEST'))
+  assert.ok(!stderr.includes('BAZ-TEST'))
+  assert.ok(!stderr.includes('EXAMPLE.COM'))
+
+  $.logOutput = 'stdout'
+  log({ scope: 'foo' }, 'foo')
+  assert.ok(stdout.includes('FOO'))
+
+  delete $.logPrint
+  delete $.logFormat
+  delete $.logIgnore
+  delete $.logOutput
+})
+
+test.run()

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -16,9 +16,8 @@ import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 import { log } from '../build/log.js'
 
-$.verbose = 0
-
 test('logger works', async () => {
+  $.verbose = 1
   let stdout = ''
   let stderr = ''
   $.logFormat = (msg) => msg.map((m) => m.toUpperCase())
@@ -45,6 +44,7 @@ test('logger works', async () => {
   delete $.logFormat
   delete $.logIgnore
   delete $.logOutput
+  $.verbose = 0
 })
 
 test.run()


### PR DESCRIPTION
closes #376
closes #405

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
- [x] Types updated

```js
test('logger works', async () => {
  let stdout = ''
  let stderr = ''
  $.logFormat = (msg) => msg.map((m) => m.toUpperCase())
  $.logPrint = (data, err) => {
    if (data) stdout += data
    if (err) stderr += err
  }
  $.logIgnore = ['b*', 'fetch']
  // NOTE first arg declares scope
  log('foo', 'foo-test')
  log('bar', 'bar-test')
  log('baz', 'baz-test')
  log('fetch', 'example.com')

  assert(stdout.includes('FOO-TEST'))
  assert(!stdout.includes('BAR-TEST'))
  assert(!stdout.includes('BAZ-TEST'))
  assert(!stdout.includes('EXAMPLE.COM'))

  $.logOutput = 'stderr'
  log('foo', 'foo')
  assert(stderr.includes('FOO'))

  delete $.logPrint
  delete $.logFormat
  delete $.logIgnore
  delete $.logOutput
})
```

`ignore` dep already comes with `globby`.

<img width="471" alt="image" src="https://user-images.githubusercontent.com/5288046/170692668-c1110c41-3a2e-4d73-afe2-958075adc1b1.png">

Pros
* filtering events by their scope: `cd/fetch/cmd,...`
* single entry point to introduce creds concealer
* custom formatting to attach mdc, timestamps, etc
* logging rules are attached to current ctx, so they can be applied to a cmd block.
* applied to spawned processes outputs
* `if (!verbose) return` at single place

Cons
* inherits `verbose` flag
* too imperative, +4 config options
* ~~not applied to spawned processes outputs, they just go as is to the root process stream~~
