### PR TITLE
Make `which` a default import in index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,7 +23,7 @@ declare module 'zx' {
   import * as _yaml from 'yaml'
   import _fetch from 'node-fetch'
   import { ParsedArgs } from 'minimist'
-  import * as _which from 'which'
+  import _which from 'which'
 
   export interface ZxTemplate {
     (


### PR DESCRIPTION
index.mjs does `import which from "which"`, not `import * as which from "which"`; this causes problems when you are in TypeScrip's module mode because it automatically disables the interop setting which makes calling a `*` imported module as a function legal.