### PR TITLE
Format Markdown via Prettier

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,6 @@
 ## Expected Behavior
 
-
 ## Actual Behavior
-
 
 ## Steps to Reproduce the Problem
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,9 @@ jobs:
           node-version: 16
       - run: npm i
       - run: npm test
-      - run: echo "//wombat-dressing-room.appspot.com/:_authToken=$AUTH_TOKEN" >> .npmrc
+      - run:
+          echo "//wombat-dressing-room.appspot.com/:_authToken=$AUTH_TOKEN" >>
+          .npmrc
         env:
           AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
       - run: npm publish

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,4 +6,3 @@ reports/
 .stryker-tmp/
 package-lock.json
 yarn.lock
-*.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🐚 zx
 
+<!-- prettier-ignore-start -->
+
 ```js
 #!/usr/bin/env zx
 
@@ -18,11 +20,12 @@ let name = 'foo bar'
 await $`mkdir /tmp/${name}`
 ```
 
-Bash is great, but when it comes to writing scripts, 
-people usually choose a more convenient programming language.
-JavaScript is a perfect choice, but standard Node.js library 
-requires additional hassle before using. The `zx` package provides
-useful wrappers around `child_process`, escapes arguments and
+<!-- prettier-ignore-end -->
+
+Bash is great, but when it comes to writing scripts, people usually choose a
+more convenient programming language. JavaScript is a perfect choice, but
+standard Node.js library requires additional hassle before using. The `zx`
+package provides useful wrappers around `child_process`, escapes arguments and
 gives sensible defaults.
 
 ## Install
@@ -35,22 +38,28 @@ npm i -g zx
 
 ## Goods
 
-[$](#command-) · [cd()](#cd) · [fetch()](#fetch) · [question()](#question) · [sleep()](#sleep) · [echo()](#echo) · [stdin()](#stdin) · [within()](#within) ·
-[chalk](#chalk-package) · [fs](#fs-package) · [os](#os-package) · [path](#path-package) · [glob](#globby-package) · [yaml](#yaml-package) · [minimist](#minimist-package) · [which](#which-package) ·
-[__filename](#__filename--__dirname) · [__dirname](#__filename--__dirname) · [require()](#require)
+[$](#command-) · [cd()](#cd) · [fetch()](#fetch) · [question()](#question) ·
+[sleep()](#sleep) · [echo()](#echo) · [stdin()](#stdin) · [within()](#within) ·
+[chalk](#chalk-package) · [fs](#fs-package) · [os](#os-package) ·
+[path](#path-package) · [glob](#globby-package) · [yaml](#yaml-package) ·
+[minimist](#minimist-package) · [which](#which-package) ·
+[\_\_filename](#__filename--__dirname) · [\_\_dirname](#__filename--__dirname) ·
+[require()](#require)
 
 ## Documentation
 
-Write your scripts in a file with `.mjs` extension in order to 
-be able to use `await` on top level. If you prefer the `.js` extension,
-wrap your scripts in something like `void async function () {...}()`.
+Write your scripts in a file with `.mjs` extension in order to be able to use
+`await` on top level. If you prefer the `.js` extension, wrap your scripts in
+something like `void async function () {...}()`.
 
 Add the following shebang to the beginning of your `zx` scripts:
+
 ```bash
 #!/usr/bin/env zx
 ```
 
 Now you will be able to run your script like so:
+
 ```bash
 chmod +x ./script.mjs
 ./script.mjs
@@ -62,8 +71,8 @@ Or via the `zx` executable:
 zx ./script.mjs
 ```
 
-All functions (`$`, `cd`, `fetch`, etc) are available straight away 
-without any imports. 
+All functions (`$`, `cd`, `fetch`, etc) are available straight away without any
+imports.
 
 Or import globals explicitly (for better autocomplete in VS Code).
 
@@ -71,10 +80,11 @@ Or import globals explicitly (for better autocomplete in VS Code).
 import 'zx/globals'
 ```
 
+<!-- prettier-ignore -->
 ### ``$`command` ``
 
-Executes a given command using the `spawn` func 
-and returns [`ProcessPromise`](#processpromise).
+Executes a given command using the `spawn` func and returns
+[`ProcessPromise`](#processpromise).
 
 Everything passed through `${...}` will be automatically escaped and quoted.
 
@@ -83,10 +93,12 @@ let name = 'foo & bar'
 await $`mkdir ${name}`
 ```
 
-**There is no need to add extra quotes.** Read more about it in 
+**There is no need to add extra quotes.** Read more about it in
 [quotes](docs/quotes.md).
 
 You can pass an array of arguments if needed:
+
+<!-- prettier-ignore-start -->
 
 ```js
 let flags = [
@@ -96,6 +108,8 @@ let flags = [
 ]
 await $`git log ${flags}`
 ```
+
+<!-- prettier-ignore-end -->
 
 If the executed program returns a non-zero exit code,
 [`ProcessOutput`](#processoutput) will be thrown.
@@ -138,9 +152,9 @@ class ProcessOutput {
 }
 ```
 
-The output of the process is captured as is. Usually, programs print a new line `\n` at the end.  
-If `ProcessOutput` is used as an argument to some other `$` process,
-**zx** will use stdout and trim the new line.
+The output of the process is captured as is. Usually, programs print a new line
+`\n` at the end. If `ProcessOutput` is used as an argument to some other `$`
+process, **zx** will use stdout and trim the new line.
 
 ```js
 let date = await $`date`
@@ -160,7 +174,8 @@ await $`pwd` // => /tmp
 
 ### `fetch()`
 
-A wrapper around the [node-fetch](https://www.npmjs.com/package/node-fetch) package.
+A wrapper around the [node-fetch](https://www.npmjs.com/package/node-fetch)
+package.
 
 ```js
 let resp = await fetch('https://medv.io')
@@ -211,7 +226,7 @@ await $`pwd` // => /home/path
 
 within(async () => {
   cd('/tmp')
-  
+
   setTimeout(async () => {
     await $`pwd` // => /tmp
   }, 1000)
@@ -220,13 +235,13 @@ within(async () => {
 await $`pwd` // => /home/path
 ```
 
- ```js
+```js
 let version = await within(async () => {
   $.prefix += 'export NVM_DIR=$HOME/.nvm; source $NVM_DIR/nvm.sh; '
   await $`nvm use 16`
   return $`node -v`
 })
-````
+```
 
 ## Packages
 
@@ -245,7 +260,7 @@ console.log(chalk.blue('Hello world!'))
 The [fs-extra](https://www.npmjs.com/package/fs-extra) package.
 
 ```js
-let {version} = await fs.readJson('./package.json')
+let { version } = await fs.readJson('./package.json')
 ```
 
 ### `os` package
@@ -282,11 +297,13 @@ console.log(YAML.parse('foo: bar').foo)
 
 ### `minimist` package
 
-The [minimist](https://www.npmjs.com/package/minimist) package available
-as global const `argv`.
+The [minimist](https://www.npmjs.com/package/minimist) package available as
+global const `argv`.
 
 ```js
-if( argv.someFlag ){ echo('yes') }
+if (argv.someFlag) {
+  echo('yes')
+}
 ```
 
 ### `which` package
@@ -323,14 +340,14 @@ Or use a CLI argument: `--prefix='set -e;'`
 
 ### `$.quote`
 
-Specifies a function for escaping special characters during 
-command substitution.
+Specifies a function for escaping special characters during command
+substitution.
 
 ### `$.verbose`
 
 Specifies verbosity. Default is `true`.
 
-In verbose mode, the `zx` prints all executed commands alongside with their 
+In verbose mode, the `zx` prints all executed commands alongside with their
 outputs.
 
 Or use a CLI argument `--quiet` to set `$.verbose = false`.
@@ -352,35 +369,38 @@ all `$` processes use `process.cwd()` by default (same as `spawn` behavior).
 
 Specifies a [logging function](src/log.ts).
 
-## Polyfills 
+## Polyfills
 
 ### `__filename` & `__dirname`
 
 In [ESM](https://nodejs.org/api/esm.html) modules, Node.js does not provide
-`__filename` and `__dirname` globals. As such globals are really handy in scripts,
-`zx` provides these for use in `.mjs` files (when using the `zx` executable).
+`__filename` and `__dirname` globals. As such globals are really handy in
+scripts, `zx` provides these for use in `.mjs` files (when using the `zx`
+executable).
 
 ### `require()`
 
-In [ESM](https://nodejs.org/api/modules.html#modules_module_createrequire_filename)
-modules, the `require()` function is not defined.
-The `zx` provides `require()` function, so it can be used with imports in `.mjs`
-files (when using `zx` executable).
+In
+[ESM](https://nodejs.org/api/modules.html#modules_module_createrequire_filename)
+modules, the `require()` function is not defined. The `zx` provides `require()`
+function, so it can be used with imports in `.mjs` files (when using `zx`
+executable).
 
 ```js
-let {version} = require('./package.json')
+let { version } = require('./package.json')
 ```
 
 ## Experimental
 
-The zx also provides a few experimental functions. Please leave a feedback about 
-those features in [the discussion](https://github.com/google/zx/discussions/299).
-To enable new features via CLI pass `--experimental` flag.
+The zx also provides a few experimental functions. Please leave a feedback about
+those features in
+[the discussion](https://github.com/google/zx/discussions/299). To enable new
+features via CLI pass `--experimental` flag.
 
 ### `retry()`
 
-Retries a callback for a few times. Will return after the first
-successful attempt, or will throw after specifies attempts count.
+Retries a callback for a few times. Will return after the first successful
+attempt, or will throw after specifies attempts count.
 
 ```js
 import { retry, expBackoff } from 'zx/experimental'
@@ -422,6 +442,7 @@ If array of values passed as argument to `$`, items of the array will be escaped
 individually and concatenated via space.
 
 Example:
+
 ```js
 let files = [...]
 await $`tar cz ${files}`
@@ -433,19 +454,20 @@ It is possible to make use of `$` and other functions via explicit imports:
 
 ```js
 #!/usr/bin/env node
-import {$} from 'zx'
+import { $ } from 'zx'
 await $`date`
 ```
 
 ### Scripts without extensions
 
 If script does not have a file extension (like `.git/hooks/pre-commit`), zx
-assumes that it is an [ESM](https://nodejs.org/api/modules.html#modules_module_createrequire_filename)
+assumes that it is an
+[ESM](https://nodejs.org/api/modules.html#modules_module_createrequire_filename)
 module.
 
 ### Markdown scripts
 
-The `zx` can execute scripts written in markdown 
+The `zx` can execute scripts written in markdown
 ([docs/markdown.md](docs/markdown.md)):
 
 ```bash
@@ -453,20 +475,21 @@ zx docs/markdown.md
 ```
 
 ### TypeScript scripts
- 
+
 ```ts
-import {$} from 'zx'
-// Or 
+import { $ } from 'zx'
+// Or
 import 'zx/globals'
 
-void async function () {
+async function main(): Promise<void> {
   await $`ls -la`
 }()
 ```
 
-Set [`"type": "module"`](https://nodejs.org/api/packages.html#packages_type) 
-in **package.json** and [`"module": "ESNext"`](https://www.typescriptlang.org/tsconfig/#module) 
-in **tsconfig.json**.
+Set [`"type": "module"`](https://nodejs.org/api/packages.html#packages_type) in
+**package.json** and
+[`"module": "ESNext"`](https://www.typescriptlang.org/tsconfig/#module) in
+**tsconfig.json**.
 
 ### Executing remote scripts
 
@@ -482,7 +505,7 @@ zx https://medv.io/game-of-life.js
 The `zx` supports executing scripts from stdin.
 
 ```js
-zx <<'EOF'
+zx << 'EOF'
 await $`pwd`
 EOF
 ```
@@ -497,8 +520,8 @@ cat package.json | zx --eval 'let v = JSON.parse(await stdin()).version; echo(v)
 
 ### Attaching a profile
 
-By default `child_process` does not include aliases and bash functions. 
-But you are still able to do it by hand. Just attach necessary directives to `$.prefix`.
+By default `child_process` does not include aliases and bash functions. But you
+are still able to do it by hand. Just attach necessary directives to `$.prefix`.
 
 ```js
 $.prefix += 'export NVM_DIR=$HOME/.nvm; source $NVM_DIR/nvm.sh; '
@@ -514,15 +537,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Build
-      env:
-        FORCE_COLOR: 3
-      run: |
-        npx zx <<'EOF'
-        await $`...`
-        EOF
+      - name: Build
+        env:
+          FORCE_COLOR: 3
+        run: |
+          npx zx <<'EOF'
+          await $`...`
+          EOF
 ```
 
 ## License

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -14,22 +14,22 @@ race, religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-*   Using welcoming and inclusive language
-*   Being respectful of differing viewpoints and experiences
-*   Gracefully accepting constructive criticism
-*   Focusing on what is best for the community
-*   Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-*   The use of sexualized language or imagery and unwelcome sexual attention or
-    advances
-*   Trolling, insulting/derogatory comments, and personal or political attacks
-*   Public or private harassment
-*   Publishing others' private information, such as a physical or electronic
-    address, without explicit permission
-*   Other conduct which could reasonably be considered inappropriate in a
-    professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
 ## Our Responsibilities
 
@@ -69,8 +69,8 @@ dispute. If you are unable to resolve the matter for any reason, or if the
 behavior is threatening or harassing, report it. We are dedicated to providing
 an environment where participants feel welcome and safe.
 
-Reports should be directed to *[PROJECT STEWARD NAME(s) AND EMAIL(s)]*, the
-Project Steward(s) for *[PROJECT NAME]*. It is the Project Steward’s duty to
+Reports should be directed to _[PROJECT STEWARD NAME(s) AND EMAIL(s)]_, the
+Project Steward(s) for _[PROJECT NAME]_. It is the Project Steward’s duty to
 receive and address reported violations of the code of conduct. They will then
 work with a committee consisting of representatives from the Open Source
 Programs Office and the Google Open Source Strategy team. If for any reason you

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,5 +24,5 @@ information on using pull requests.
 
 ## Community Guidelines
 
-This project follows [Google's Open Source Community
-Guidelines](https://opensource.google/conduct/).
+This project follows
+[Google's Open Source Community Guidelines](https://opensource.google/conduct/).

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -2,26 +2,29 @@
 
 ## Output gets truncated
 
-This is a known issue with `console.log()` (see [nodejs/node#6379](https://github.com/nodejs/node/issues/6379)). 
-It's caused by different behaviour of `console.log()` writing to the terminal vs
-to a file. If a process calls `process.exit()`, buffered output will be truncated.
-To prevent this, the process should use `process.exitCode = 1` and wait for the 
-process to exit itself. Or use something like [exit](https://www.npmjs.com/package/exit) package.
+This is a known issue with `console.log()` (see
+[nodejs/node#6379](https://github.com/nodejs/node/issues/6379)). It's caused by
+different behaviour of `console.log()` writing to the terminal vs to a file. If
+a process calls `process.exit()`, buffered output will be truncated. To prevent
+this, the process should use `process.exitCode = 1` and wait for the process to
+exit itself. Or use something like [exit](https://www.npmjs.com/package/exit)
+package.
 
 Workaround is to write to a temp file:
+
 ```js
 let tmp = await $`mktemp` // Creates a temp file.
-let {stdout} = await $`cmd > ${tmp}; cat ${tmp}`
+let { stdout } = await $`cmd > ${tmp}; cat ${tmp}`
 ```
 
 ## Colors in subprocess
 
-You may see what tools invoked with `await $` don't show colors, compared to 
-what you see in a terminal. This is because, the subprocess does not think it's 
-a TTY and the subprocess turns off colors. Usually there is a way force 
-the subprocess to add colors.
+You may see what tools invoked with `await $` don't show colors, compared to
+what you see in a terminal. This is because, the subprocess does not think it's
+a TTY and the subprocess turns off colors. Usually there is a way force the
+subprocess to add colors.
 
 ```js
-process.env.FORCE_COLOR='1'
+process.env.FORCE_COLOR = '1'
 await $`cmd`
 ```

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -1,7 +1,7 @@
 # Markdown Scripts
 
 It's possible to write scripts using markdown. Only code blocks will be executed
-by zx. 
+by zx.
 
 > You can run this markdown file:
 >
@@ -37,6 +37,6 @@ Other code blocks are ignored:
 
 ```css
 body .hero {
-    margin: 42px;
+  margin: 42px;
 }
 ```

--- a/docs/process-promise.md
+++ b/docs/process-promise.md
@@ -10,8 +10,8 @@ await p
 
 ## `stdin`
 
-Returns a writable stream of the stdin process. Accessing
-this getter will trigger execution of a subprocess with [`stdio('pipe')`](#stdio).
+Returns a writable stream of the stdin process. Accessing this getter will
+trigger execution of a subprocess with [`stdio('pipe')`](#stdio).
 
 Do not forget to end the stream.
 
@@ -36,7 +36,7 @@ for await (const chunk of p.stdout) {
 
 ## `exitCode`
 
-Returns a promise which resolves to the exit code of the process. 
+Returns a promise which resolves to the exit code of the process.
 
 ```js
 if (await $`[[ -d path ]]`.exitCode == 0) {
@@ -48,6 +48,8 @@ if (await $`[[ -d path ]]`.exitCode == 0) {
 
 Redirects the stdout of the process.
 
+<!-- prettier-ignore-start -->
+
 ```js
 await $`echo "Hello, stdout!"`
   .pipe(fs.createWriteStream('/tmp/output.txt'))
@@ -55,12 +57,18 @@ await $`echo "Hello, stdout!"`
 await $`cat /tmp/output.txt`
 ```
 
+<!-- prettier-ignore-end -->
+
 Pipes can be used to show a real-time output of the process:
+
+<!-- prettier-ignore-start -->
 
 ```js
 await $`echo 1; sleep 1; echo 2; sleep 1; echo 3;`
   .pipe(process.stdout)
 ```
+
+<!-- prettier-ignore-end -->
 
 The `pipe()` method can combine `$` processes. Same as `|` in bash:
 
@@ -82,7 +90,7 @@ await $`find ./examples -type f -print0`
 
 ## `kill()`
 
-Kills the process and all children. 
+Kills the process and all children.
 
 By default, signal `SIGTERM` is sent. You can specify a signal via an argument.
 
@@ -94,7 +102,7 @@ await p
 
 ## `stdio()`
 
-Specifies a stdio for the process. 
+Specifies a stdio for the process.
 
 Default is `.stdio('inherit', 'pipe', 'pipe')`.
 

--- a/docs/quotes.md
+++ b/docs/quotes.md
@@ -1,6 +1,6 @@
 # Quotes
 
-When passing arguments to `${...}` there is no need to add quotes. **Quotes will 
+When passing arguments to `${...}` there is no need to add quotes. **Quotes will
 be added automatically if needed.**
 
 ```js
@@ -15,7 +15,7 @@ mkdir $'foo & bar'
 $'ls' $'-la'
 ```
 
-If you add quotes `"${name}"`, it will produce a wrong command. 
+If you add quotes `"${name}"`, it will produce a wrong command.
 
 If you need to add something extra, consider putting it inside curly brackets.
 
@@ -32,9 +32,11 @@ await $`mkdir path/to-dir/${name}`
 ### Array of arguments
 
 The `zx` can also take an array or arguments in the `${...}`. Items of the array
-will be quoted separately and concatenated via a space. 
+will be quoted separately and concatenated via a space.
 
 Do **not** add a `.join(' ')`.
+
+<!-- prettier-ignore-start -->
 
 ```js
 let flags = [
@@ -45,8 +47,10 @@ let flags = [
 await $`git log ${flags}`
 ```
 
-If you already have a string with arrays, it's your responsibility
-to correctly parse it and distinguish separate arguments. For example like this:
+<!-- prettier-ignore-end -->
+
+If you already have a string with arrays, it's your responsibility to correctly
+parse it and distinguish separate arguments. For example like this:
 
 ```js
 await $`git log ${'--oneline --decorate --color'.split(' ')}`
@@ -55,9 +59,9 @@ await $`git log ${'--oneline --decorate --color'.split(' ')}`
 ### globbing and `~`
 
 As everything passed through `${...}` will be escaped, you can't use `~` or glob
-syntax. 
+syntax.
 
-In order for this to work the zx provides 
+In order for this to work the zx provides
 [globby package](../README.md#globby-package).
 
 For instead of this:
@@ -73,5 +77,3 @@ Use `glob` function and `os` package:
 let files = await glob(os.homedir() + '/dev/**/*.md')
 await $`ls ${files}`
 ```
-
-

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "zx.js"
   ],
   "prettier": {
+    "proseWrap": "always",
     "semi": false,
     "singleQuote": true
   },

--- a/test/fixtures/markdown.md
+++ b/test/fixtures/markdown.md
@@ -2,7 +2,6 @@
 
 ignore
 
->
 > ```
 > echo ignore
 > ```
@@ -31,5 +30,6 @@ echo "$VAR"
 Other code blocks are ignored:
 
 ```css
-.ignore {}
+.ignore {
+}
 ```


### PR DESCRIPTION
This enables Markdown formatting via Prettier. I am using [range ignores](https://prettier.io/docs/en/ignore.html#range-ignore) to stop Prettier from messing up the code examples. I have enabled the [printWidth](https://prettier.io/docs/en/options.html#print-width) option to wrap text at 80 characters. A preview of the changes is available at https://github.com/kevgo/zx/tree/kg-prettier-md.

I admit that the range ignores add some clutter, but they don't show up in the rendered HTML file and overall the Markdown code seems in better shape with Prettier formatting than without, so I think the extra complexity is worth it here.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
- [ ] Types updated
