### PR TITLE
fix: patch default shell on win32

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -71,8 +71,10 @@ export const defaults: Options = {
 }
 
 try {
-  defaults.shell = which.sync('bash')
-  defaults.prefix = 'set -euo pipefail;'
+  if (process.platform !== 'win32') {
+    defaults.shell = which.sync('bash')
+    defaults.prefix = 'set -euo pipefail;'
+  }
 } catch (err) {
   // ¯\_(ツ)_/¯
 }


### PR DESCRIPTION
Fixes #398

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
- [x] Types updated
