### PR TITLE
feat: pass store to `within` callback, pass options to configure `within` context

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,18 @@ let version = await within(async () => {
 })
 ```
 
+You may also pass zx options preset to configure the bound context.
+
+```js
+await within(async () => {
+  await $`yarn build`
+  await $`yarn test`
+
+  // $.verbose === true
+  // $.cwd === 'packages/foo'
+}, {verbose: true, cwd: 'packages/foo'})
+```
+
 ## Packages
 
 The following packages are available without importing inside scripts.

--- a/src/core.ts
+++ b/src/core.ts
@@ -370,7 +370,10 @@ export class ProcessOutput extends Error {
   }
 }
 
-export function within<R, O extends Partial<Options>>(callback: (store: Options) => R, opts?: O): R {
+export function within<R, O extends Partial<Options>>(
+  callback: (store: Options) => R,
+  opts?: O
+): R {
   const store = { ...getStore(), ...opts }
   return storage.run(store, callback, store)
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -37,7 +37,7 @@ export type Shell = (
 
 const processCwd = Symbol('processCwd')
 
-export type Options = {
+export interface Options {
   [processCwd]: string
   cwd?: string
   verbose: boolean
@@ -370,8 +370,9 @@ export class ProcessOutput extends Error {
   }
 }
 
-export function within<R>(callback: () => R): R {
-  return storage.run({ ...getStore() }, callback)
+export function within<R, O extends Partial<Options>>(callback: (store: Options) => R, opts?: O): R {
+  const store = { ...getStore(), ...opts }
+  return storage.run(store, callback, store)
 }
 
 function syncCwd() {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -322,6 +322,32 @@ test('within() works', async () => {
   await promise
 })
 
+test('within() `callback` injects `store` extra and gets a `store` ref as the first argument', async () => {
+  let resolve, reject
+  let promise = new Promise((...args) => ([resolve, reject] = args))
+
+  function yes() {
+    assert.equal($.verbose, true)
+    resolve()
+  }
+
+  $.verbose = false
+  assert.equal($.verbose, false)
+
+  within((store) => {
+    assert.equal(store.verbose, true)
+    assert.equal($.verbose, true)
+    assert.equal($.cwd, '/tmp')
+
+    setTimeout(yes, 10)
+  }, {verbose: true, cwd: '/tmp'})
+
+  assert.equal($.verbose, false)
+  assert.equal($.cwd, undefined)
+
+  await promise
+})
+
 test('within() restores previous cwd', async () => {
   let resolve, reject
   let promise = new Promise((...args) => ([resolve, reject] = args))

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -334,13 +334,16 @@ test('within() `callback` injects `store` extra and gets a `store` ref as the fi
   $.verbose = false
   assert.equal($.verbose, false)
 
-  within((store) => {
-    assert.equal(store.verbose, true)
-    assert.equal($.verbose, true)
-    assert.equal($.cwd, '/tmp')
+  within(
+    (store) => {
+      assert.equal(store.verbose, true)
+      assert.equal($.verbose, true)
+      assert.equal($.cwd, '/tmp')
 
-    setTimeout(yes, 10)
-  }, {verbose: true, cwd: '/tmp'})
+      setTimeout(yes, 10)
+    },
+    { verbose: true, cwd: '/tmp' }
+  )
 
   assert.equal($.verbose, false)
   assert.equal($.cwd, undefined)


### PR DESCRIPTION
- [x] Tests pass
- [x] Appropriate changes to README are included in PR

```js
const fooPreset = { cwd: 'packages/foo', quote: v => v}
const barPreset= { cwd: 'packages/bar', log: reporter}
const debugPreset = {env: {DEBUG: '*', verbose: true}}

const build = (preset) =>  within(async (store) => {
  try {
      await $`yarn build`
  } catch() {
     Object.assign(store, debugPreset)
     await $`yarn build`
  }
}, preset)

const test = (preset) =>  within(async (store) => {
  try {
      await $`yarn build`
  } catch() {
     Object.assign(store, debugPreset)
     await $`yarn build`
  }
}, preset)

await build(fooPreset)
await build(barPreset)
```
