### PR TITLE
fix: add the "@" and ":" regex for quote

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -30,7 +30,7 @@ export function isString(obj: any) {
 }
 
 export function quote(arg: string) {
-  if (/^[a-z0-9/_.-]+$/i.test(arg) || arg === '') {
+  if (/^[a-z0-9/@:_.-]+$/i.test(arg) || arg === '') {
     return arg
   }
   return (


### PR DESCRIPTION
I want to use ZX to run some code like this:
```
const testRepo = "git@github.com:user/repo.git"
await $`git clone ${testRepo}`
```
But I got ` git clone $'git@github.com:user/repo.git'` 
So I want to add `@` and `:` to the regex of quote.