### PR TITLE
fix: avoid redundant `$.verbose` reassignment on CLI init

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,9 @@ import { randomId } from './util.js'
 await (async function main() {
   const globals = './globals.js'
   await import(globals)
-  $.verbose = !argv.quiet
+  if (argv.quiet) {
+    $.verbose = false
+  }
   if (typeof argv.shell === 'string') {
     $.shell = argv.shell
   }


### PR DESCRIPTION
zx-extra/index.js

```js
$.verbose = false
```

zx-extra/cli.js
```js
#!/usr/bin/env node

import './index.mjs'
import 'zx/cli'

$.verbose // true
```



