### PR TITLE
Dep: update node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zx",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zx",
-      "version": "7.0.7",
+      "version": "7.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/fs-extra": "^9.0.13",
@@ -18,7 +18,7 @@
         "fs-extra": "^10.1.0",
         "globby": "^13.1.2",
         "minimist": "^1.2.6",
-        "node-fetch": "3.2.8",
+        "node-fetch": "3.2.10",
         "ps-tree": "^1.2.0",
         "which": "^2.0.2",
         "yaml": "^2.1.1"
@@ -3677,9 +3677,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
-      "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -8204,9 +8204,9 @@
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
-      "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
       "requires": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "fs-extra": "^10.1.0",
     "globby": "^13.1.2",
     "minimist": "^1.2.6",
-    "node-fetch": "3.2.8",
+    "node-fetch": "3.2.10",
     "ps-tree": "^1.2.0",
     "which": "^2.0.2",
     "yaml": "^2.1.1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "lib": ["ES2021"],
+    "lib": ["ES2021", "DOM"],
     "moduleResolution": "nodenext",
     "module": "nodenext",
     "strict": true,


### PR DESCRIPTION
Fixes #506 

Minor fix for [CVE-2022-2596](https://github.com/advisories/GHSA-vp56-6g26-6827)

Also added a temp fix for a type issue brought in by the latest update in node-fetch. 
See: https://github.com/node-fetch/node-fetch/issues/1617

First contribution, so any suggestions or things I've missed are greatly welcomed.

- [x] Tests pass (locally)
- [x] Appropriate changes to README are included in PR
- [x] Types updated
