### PR TITLE
Documented `nothrow`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ try {
 }
 ```
 
+Alternatively you can wrap `$` in a `nothrow()`, which will print the error but continue execution.
+
+```js
+await nothrow($`exit 1`)
+console.debug('still executing...')
+```
+
 ### `ProcessPromise`
 
 ```ts


### PR DESCRIPTION
Documented `nothrow` as a means to continue execution when a `ProcessOutput` error is thrown.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [X] Appropriate changes to README are included in PR
- [ ] Types updated
