### PR TITLE
add postfix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,9 +368,17 @@ Specifies a `spawn` api. Defaults to `require('child_process').spawn`.
 
 Specifies the command that will be prefixed to all commands run.
 
-Default is `set -euo pipefail;`.
+Default is `set -euo pipefail;` for bash, and `''` for powershell.
 
 Or use a CLI argument: `--prefix='set -e;'`
+
+### `$.postfix`
+
+Same as `$.prefix` but applied after the all commands. 
+
+Default is `''` for bash, and `; exit $LastExitCode` for powershell.
+
+Or use a CLI argument: `--postfix='; exit $LastExitCode'`
 
 ### `$.quote`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,7 @@ function printUsage() {
    --quiet              don't echo commands
    --shell=<path>       custom shell binary
    --prefix=<command>   prefix all commands
+   --postfix=<command>  postfix all commands
    --eval=<js>, -e      evaluate script 
    --install, -i        install dependencies
    --experimental       enable experimental features
@@ -48,7 +49,7 @@ function printUsage() {
 }
 
 const argv = minimist(process.argv.slice(2), {
-  string: ['shell', 'prefix', 'eval'],
+  string: ['shell', 'prefix', 'postfix', 'eval'],
   boolean: ['version', 'help', 'quiet', 'install', 'repl', 'experimental'],
   alias: { e: 'eval', i: 'install', v: 'version', h: 'help' },
   stopEarly: true,
@@ -60,6 +61,7 @@ await (async function main() {
   if (argv.quiet) $.verbose = false
   if (argv.shell) $.shell = argv.shell
   if (argv.prefix) $.prefix = argv.prefix
+  if (argv.postfix) $.postfix = argv.postfix
   if (argv.experimental) {
     Object.assign(global, await import('./experimental.js'))
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -46,6 +46,7 @@ export type Options = {
   env: NodeJS.ProcessEnv
   shell: string | boolean
   prefix: string
+  postfix: string
   quote: typeof quote
   spawn: typeof spawn
   log: typeof log
@@ -67,6 +68,7 @@ export const defaults: Options = {
   env: process.env,
   shell: true,
   prefix: '',
+  postfix: '',
   quote: () => {
     throw new Error('No quote function is defined: https://ï.at/no-quote-func')
   },
@@ -81,6 +83,7 @@ try {
 } catch (err) {
   if (process.platform == 'win32') {
     defaults.shell = which.sync('powershell.exe')
+    defaults.postfix = '; exit $LastExitCode'
     defaults.quote = quotePowerShell
   }
 }
@@ -177,7 +180,7 @@ export class ProcessPromise extends Promise<ProcessOutput> {
       cmd: this._command,
       verbose: $.verbose && !this._quiet,
     })
-    this.child = $.spawn($.prefix + this._command, {
+    this.child = $.spawn($.prefix + this._command + $.postfix, {
       cwd: $.cwd ?? $[processCwd],
       shell: typeof $.shell === 'string' ? $.shell : true,
       stdio: this._stdio,

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -96,6 +96,13 @@ test('supports `--prefix` flag ', async () => {
   assert.ok(p.stderr.includes(prefix))
 })
 
+test('supports `--postfix` flag ', async () => {
+  let postfix = '; exit 0'
+  let p =
+    await $`node build/cli.js --postfix=${postfix} <<< '$\`echo \${$.postfix}\`'`
+  assert.ok(p.stderr.includes(postfix))
+})
+
 test('scripts from https', async () => {
   $`cat ${path.resolve('test/fixtures/echo.http')} | nc -l 8080`
   let out = await $`node build/cli.js http://127.0.0.1:8080/echo.mjs`


### PR DESCRIPTION
I'm using zx with powershell, and I noticed that when a command sets an exit code instead of throwing an exception (ex. Azure CLI does this) the exit code doesn't get passed through by default. To resolve this issue I added a `$.postfix` option:
```js
$.postfix = '; exit $LastExitCode'
await $`az ...` // now throws an exception on failure
```

I've also added a CLI option and updated the default powershell behavior to include this postfix. These changes work for me but if there is a better way I'd be happy to rework them.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
- [x] Types updated
