### PR TITLE
cli: avoid top level await

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,7 +54,16 @@ const argv = minimist(process.argv.slice(2), {
   stopEarly: true,
 })
 
-await (async function main() {
+main().catch((err) => {
+  if (err instanceof ProcessOutput) {
+    console.error('Error:', err.message)
+  } else {
+    console.error(err)
+  }
+  process.exitCode = 1
+})
+
+async function main() {
   const globals = './globals.js'
   await import(globals)
   if (argv.quiet) $.verbose = false
@@ -94,14 +103,7 @@ await (async function main() {
     ? url.fileURLToPath(firstArg)
     : resolve(firstArg)
   await importPath(filepath)
-})().catch((err) => {
-  if (err instanceof ProcessOutput) {
-    console.error('Error:', err.message)
-  } else {
-    console.error(err)
-  }
-  process.exitCode = 1
-})
+}
 
 async function runScript(script: string) {
   const filepath = join(process.cwd(), `zx-${randomId()}.mjs`)


### PR DESCRIPTION
Hello,

This change is motivated for making possible to port zx to CJS:

```
❯ npx esbuild --format=cjs node_modules/zx/build/cli.js
✘ [ERROR] Top-level await is currently not supported with the "cjs" output format

    node_modules/.pnpm/zx@7.1.1/node_modules/zx/build/cli.js:52:0:
      52 │ await (async function main () {
         ╵ ~~~~~

1 error
```

It isn't a big deal and potentially more user can adopt zx 🙂