### PR TITLE
feat: support passing arbitrary HTTP headers when fetching remote scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,12 @@ downloaded and executed.
 zx https://medv.io/game-of-life.js
 ```
 
+You can specify arbitrary headers by specifying `--header` parameters.
+
+```bash
+zx --header User-Agent=zx --header X-Custom=42 https://medv.io/game-of-life.js
+```
+
 ### Executing scripts from stdin
 
 The `zx` supports executing scripts from stdin.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -15,6 +15,7 @@
 import { suite } from 'uvu'
 import * as assert from 'uvu/assert'
 import '../build/globals.js'
+import fs from 'fs-extra'
 
 const test = suite('cli')
 
@@ -100,6 +101,17 @@ test('scripts from https', async () => {
   $`cat ${path.resolve('test/fixtures/echo.http')} | nc -l 8080`
   let out = await $`node build/cli.js http://127.0.0.1:8080/echo.mjs`
   assert.match(out.stderr, 'test')
+})
+
+test('supports `--header` flag', async () => {
+  const tmpFile = path.join(
+    os.tmpdir(),
+    `${new Date().getTime().toString(36)}.text`
+  )
+  $`cat ${path.resolve('test/fixtures/echo.http')} | nc -l 8080 > ${tmpFile}`
+  await $`node build/cli.js --header foo=bar http://127.0.0.1:8080/echo.mjs`
+  const requestData = await fs.readFile(tmpFile)
+  assert.match(requestData, 'foo: bar')
 })
 
 test('scripts from https not ok', async () => {


### PR DESCRIPTION
Apologies for not opening an issue for discussion first.

This PR adds support for providing headers that will be supplied when fetching remote scripts. The main use case is to enable fetching scripts that require some form of authentication header in order to access.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
