### PR TITLE
Add preliminary Deno tests

### DIFF
--- a/.github/workflows/test-deno.yml
+++ b/.github/workflows/test-deno.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
+      - run: deno task build
       - run: |
           for test in test/*.test.js; do
             deno run -A $test
@@ -24,6 +25,7 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
+      - run: deno task build
       - run: |
           for test in test/*.test.js; do
             deno run -A $test

--- a/.github/workflows/test-deno.yml
+++ b/.github/workflows/test-deno.yml
@@ -1,0 +1,30 @@
+name: Test Deno
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - run: |
+          for test in test/*.test.js; do
+            deno run -A $test
+          done
+
+  win32:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - run: |
+          for test in test/*.test.js; do
+            deno run -A $test
+          done

--- a/.github/workflows/test-deno.yml
+++ b/.github/workflows/test-deno.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           deno-version: v1.x
       - run: deno task build
-      - run: deno test -A test/*.test.js
+      - run: deno test -A
         env:
           FORCE_COLOR: 3
 
@@ -25,6 +25,6 @@ jobs:
         with:
           deno-version: v1.x
       - run: deno task build
-      - run: deno test -A test/*.test.js
+      - run: deno test -A
         env:
           FORCE_COLOR: 3

--- a/.github/workflows/test-deno.yml
+++ b/.github/workflows/test-deno.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           deno-version: v1.x
       - run: deno task build
-      - run: deno test -A
+      - run: deno test -A test/win32.test.js
         env:
           FORCE_COLOR: 3

--- a/.github/workflows/test-deno.yml
+++ b/.github/workflows/test-deno.yml
@@ -16,6 +16,8 @@ jobs:
           for test in test/*.test.js; do
             deno run -A $test
           done
+        env:
+          FORCE_COLOR: 3
 
   win32:
     runs-on: windows-latest
@@ -30,3 +32,5 @@ jobs:
           for test in test/*.test.js; do
             deno run -A $test
           done
+        env:
+          FORCE_COLOR: 3

--- a/.github/workflows/test-deno.yml
+++ b/.github/workflows/test-deno.yml
@@ -12,10 +12,7 @@ jobs:
         with:
           deno-version: v1.x
       - run: deno task build
-      - run: |
-          for test in test/*.test.js; do
-            deno run -A $test
-          done
+      - run: deno test -A test/*.test.js
         env:
           FORCE_COLOR: 3
 
@@ -28,9 +25,6 @@ jobs:
         with:
           deno-version: v1.x
       - run: deno task build
-      - run: |
-          for test in test/*.test.js; do
-            deno run -A $test
-          done
+      - run: deno test -A test/*.test.js
         env:
           FORCE_COLOR: 3

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@
 
 import fs from 'fs-extra'
 import minimist from 'minimist'
+import process from 'node:process'
 import { createRequire } from 'node:module'
 import { basename, dirname, extname, join, resolve } from 'node:path'
 import url from 'node:url'
@@ -38,7 +39,7 @@ function printUsage() {
    --quiet              don't echo commands
    --shell=<path>       custom shell binary
    --prefix=<command>   prefix all commands
-   --eval=<js>, -e      evaluate script 
+   --eval=<js>, -e      evaluate script
    --install, -i        install dependencies
    --experimental       enable experimental features
    --version, -v        print current zx version
@@ -61,7 +62,7 @@ await (async function main() {
   if (argv.shell) $.shell = argv.shell
   if (argv.prefix) $.prefix = argv.prefix
   if (argv.experimental) {
-    Object.assign(global, await import('./experimental.js'))
+    Object.assign(globalThis, await import('./experimental.js'))
   }
   if (argv.version) {
     console.log(getVersion())
@@ -179,7 +180,7 @@ async function importPath(filepath: string, origin = filepath) {
   const __filename = resolve(origin)
   const __dirname = dirname(__filename)
   const require = createRequire(origin)
-  Object.assign(global, { __filename, __dirname, require })
+  Object.assign(globalThis, { __filename, __dirname, require })
   await import(url.pathToFileURL(filepath).toString())
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import assert from 'node:assert'
+import process from 'node:process'
+import { setImmediate } from 'node:timers'
 import { ChildProcess, spawn, StdioNull, StdioPipe } from 'node:child_process'
 import { AsyncLocalStorage, createHook } from 'node:async_hooks'
 import { Readable, Writable } from 'node:stream'

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -14,7 +14,7 @@
 
 import * as _ from './index.js'
 
-Object.assign(global, _)
+Object.assign(globalThis, _)
 
 declare global {
   type ProcessPromise = _.ProcessPromise

--- a/src/goods.ts
+++ b/src/goods.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import assert from 'node:assert'
+import process from 'node:process'
 import * as globbyModule from 'globby'
 import minimist from 'minimist'
 import nodeFetch, { RequestInfo, RequestInit } from 'node-fetch'
@@ -32,7 +33,7 @@ export { ssh } from 'webpod'
 export let argv = minimist(process.argv.slice(2))
 export function updateArgv(args: string[]) {
   argv = minimist(args)
-  ;(global as any).argv = argv
+  ;(globalThis as any).argv = argv
 }
 
 export const globby = Object.assign(function globby(

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -15,12 +15,12 @@
 import chalk from 'chalk'
 import os from 'node:os'
 import path from 'node:path'
-import repl from 'node:repl'
 import { inspect } from 'node:util'
 import { ProcessOutput, defaults } from './core.js'
 
-export function startRepl() {
+export async function startRepl() {
   defaults.verbose = false
+  const repl = await import('node:repl')
   const r = repl.start({
     prompt: chalk.greenBright.bold('❯ '),
     useGlobal: true,

--- a/test-util.js
+++ b/test-util.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { suite } from '../test-util.js'
-import * as assert from 'uvu/assert'
-import '../build/globals.js'
+import { suite as uvuSuite } from 'uvu'
 
-const test = suite('experimental')
+export const isDeno = typeof Deno !== 'undefined'
+export const runtime = isDeno ? ['deno', 'run', '-A'] : 'node'
 
-$.verbose = false
-
-test.run()
+export const suite = isDeno
+  ? () => {
+      const runner = (name, fn) =>
+        Deno.test({
+          name,
+          fn,
+          sanitizeResources: false,
+          sanitizeOps: false,
+        })
+      const noop = () => {}
+      runner.run = noop
+      runner.before = { each: noop }
+      return runner
+    }
+  : uvuSuite

--- a/test-util.js
+++ b/test-util.js
@@ -17,6 +17,7 @@ import { suite as uvuSuite } from 'uvu'
 export const isDeno = typeof Deno !== 'undefined'
 export const runtime = isDeno ? ['deno', 'run', '-A'] : 'node'
 
+const noop = () => {}
 export const suite = isDeno
   ? () => {
       const runner = (name, fn) =>
@@ -26,7 +27,6 @@ export const suite = isDeno
           sanitizeResources: false,
           sanitizeOps: false,
         })
-      const noop = () => {}
       runner.run = noop
       runner.before = { each: noop }
       return runner

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -199,7 +199,9 @@ test('argv works with zx and node', async () => {
     `global {"_":["bar"]}\nimported {"_":["bar"]}\n`
   )
   assert.is(
-    (await $`${runtime} build/cli.js --eval 'console.log(argv._)' baz`).toString(),
+    (
+      await $`${runtime} build/cli.js --eval 'console.log(argv._)' baz`
+    ).toString(),
     `[ 'baz' ]\n`
   )
 })

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { suite } from 'uvu'
+import { suite, isDeno, runtime } from '../test-util.js'
 import * as assert from 'uvu/assert'
 import process from 'node:process'
 import '../build/globals.js'
 
-const isDeno = typeof Deno !== 'undefined'
-const runtime = isDeno ? ['deno', 'run', '-A'] : 'node'
 const test = suite('cli')
 
 $.verbose = false

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -14,8 +14,11 @@
 
 import { suite } from 'uvu'
 import * as assert from 'uvu/assert'
+import process from 'node:process'
 import '../build/globals.js'
 
+const isDeno = typeof Deno !== 'undefined'
+const runtime = isDeno ? ['deno', 'run', '-A'] : 'node'
 const test = suite('cli')
 
 $.verbose = false
@@ -35,25 +38,26 @@ test('promise resolved', async () => {
 })
 
 test('prints version', async () => {
-  assert.match((await $`node build/cli.js -v`).toString(), /\d+.\d+.\d+/)
+  assert.match((await $`${runtime} build/cli.js -v`).toString(), /\d+.\d+.\d+/)
 })
 
 test('prints help', async () => {
-  let p = $`node build/cli.js -h`
+  let p = $`${runtime} build/cli.js -h`
   p.stdin.end()
   let help = await p
   assert.match(help.stdout, 'zx')
 })
 
 test('zx prints usage', async () => {
-  let p = $`node build/cli.js`
+  let p = $`${runtime} build/cli.js`
   p.stdin.end()
   let out = await p
   assert.match(out.stdout, 'A tool for writing better scripts')
 })
 
 test('starts repl with --repl', async () => {
-  let p = $`node build/cli.js --repl`
+  if (isDeno) return
+  let p = $`${runtime} build/cli.js --repl`
   p.stdin.write('await $`echo f"o"o`\n')
   p.stdin.write('"b"+"ar"\n')
   p.stdin.end()
@@ -63,7 +67,8 @@ test('starts repl with --repl', async () => {
 })
 
 test('starts repl with verbosity off', async () => {
-  let p = $`node build/cli.js --repl`
+  if (isDeno) return
+  let p = $`${runtime} build/cli.js --repl`
   p.stdin.write('"verbose" + " is " + $.verbose\n')
   p.stdin.end()
   let out = await p
@@ -76,7 +81,7 @@ test('supports `--experimental` flag', async () => {
 })
 
 test('supports `--quiet` flag', async () => {
-  let p = await $`node build/cli.js test/fixtures/markdown.md`
+  let p = await $`${runtime} build/cli.js test/fixtures/markdown.md`
   assert.ok(!p.stderr.includes('ignore'), 'ignore was printed')
   assert.ok(p.stderr.includes('hello'), 'no hello')
   assert.ok(p.stdout.includes('world'), 'no world')
@@ -85,31 +90,33 @@ test('supports `--quiet` flag', async () => {
 test('supports `--shell` flag ', async () => {
   let shell = $.shell
   let p =
-    await $`node build/cli.js --shell=${shell} <<< '$\`echo \${$.shell}\`'`
+    await $`${runtime} build/cli.js --shell=${shell} <<< '$\`echo \${$.shell}\`'`
   assert.ok(p.stderr.includes(shell))
 })
 
 test('supports `--prefix` flag ', async () => {
   let prefix = 'set -e;'
   let p =
-    await $`node build/cli.js --prefix=${prefix} <<< '$\`echo \${$.prefix}\`'`
+    await $`${runtime} build/cli.js --prefix=${prefix} <<< '$\`echo \${$.prefix}\`'`
   assert.ok(p.stderr.includes(prefix))
 })
 
 test('scripts from https', async () => {
+  if (isDeno) return
   $`cat ${path.resolve('test/fixtures/echo.http')} | nc -l 8080`
-  let out = await $`node build/cli.js http://127.0.0.1:8080/echo.mjs`
+  let out = await $`${runtime} build/cli.js http://127.0.0.1:8080/echo.mjs`
   assert.match(out.stderr, 'test')
 })
 
 test('scripts from https not ok', async () => {
+  if (isDeno) return
   $`echo $'HTTP/1.1 500\n\n' | nc -l 8081`
-  let out = await $`node build/cli.js http://127.0.0.1:8081`.nothrow()
+  let out = await $`${runtime} build/cli.js http://127.0.0.1:8081`.nothrow()
   assert.match(out.stderr, "Error: Can't get")
 })
 
 test('scripts with no extension', async () => {
-  await $`node build/cli.js test/fixtures/no-extension`
+  await $`${runtime} build/cli.js test/fixtures/no-extension`
   assert.ok(
     /Test file to verify no-extension didn't overwrite similarly name .mjs file./.test(
       (await fs.readFile('test/fixtures/no-extension.mjs')).toString()
@@ -119,36 +126,36 @@ test('scripts with no extension', async () => {
 
 test('require() is working from stdin', async () => {
   let out =
-    await $`node build/cli.js <<< 'console.log(require("./package.json").name)'`
+    await $`${runtime} build/cli.js <<< 'console.log(require("./package.json").name)'`
   assert.match(out.stdout, 'zx')
 })
 
 test('require() is working in ESM', async () => {
-  await $`node build/cli.js test/fixtures/require.mjs`
+  await $`${runtime} build/cli.js test/fixtures/require.mjs`
 })
 
 test('__filename & __dirname are defined', async () => {
-  await $`node build/cli.js test/fixtures/filename-dirname.mjs`
+  await $`${runtime} build/cli.js test/fixtures/filename-dirname.mjs`
 })
 
 test('markdown scripts are working', async () => {
-  await $`node build/cli.js docs/markdown.md`
+  await $`${runtime} build/cli.js docs/markdown.md`
 })
 
 test('markdown scripts are working', async () => {
-  await $`node build/cli.js docs/markdown.md`
+  await $`${runtime} build/cli.js docs/markdown.md`
 })
 
 test('exceptions are caught', async () => {
-  let out1 = await $`node build/cli.js <<<${'await $`wtf`'}`.nothrow()
+  let out1 = await $`${runtime} build/cli.js <<<${'await $`wtf`'}`.nothrow()
   assert.match(out1.stderr, 'Error:')
-  let out2 = await $`node build/cli.js <<<'throw 42'`.nothrow()
+  let out2 = await $`${runtime} build/cli.js <<<'throw 42'`.nothrow()
   assert.match(out2.stderr, '42')
 })
 
 test('eval works', async () => {
-  assert.is((await $`node build/cli.js --eval 'echo(42)'`).stdout, '42\n')
-  assert.is((await $`node build/cli.js -e='echo(69)'`).stdout, '69\n')
+  assert.is((await $`${runtime} build/cli.js --eval 'echo(42)'`).stdout, '42\n')
+  assert.is((await $`${runtime} build/cli.js -e='echo(69)'`).stdout, '69\n')
 })
 
 test('eval works with stdin', async () => {
@@ -182,22 +189,24 @@ test('executes a script from $PATH', async () => {
 })
 
 test('argv works with zx and node', async () => {
+  if (isDeno) return
   assert.is(
-    (await $`node build/cli.js test/fixtures/argv.mjs foo`).toString(),
+    (await $`${runtime} build/cli.js test/fixtures/argv.mjs foo`).toString(),
     `global {"_":["foo"]}\nimported {"_":["foo"]}\n`
   )
   assert.is(
-    (await $`node test/fixtures/argv.mjs bar`).toString(),
+    (await $`${runtime} test/fixtures/argv.mjs bar`).toString(),
     `global {"_":["bar"]}\nimported {"_":["bar"]}\n`
   )
   assert.is(
-    (await $`node build/cli.js --eval 'console.log(argv._)' baz`).toString(),
+    (await $`${runtime} build/cli.js --eval 'console.log(argv._)' baz`).toString(),
     `[ 'baz' ]\n`
   )
 })
 
 test('exit code can be set', async () => {
-  let p = await $`node build/cli.js test/fixtures/exit-code.mjs`.nothrow()
+  if (isDeno) return
+  let p = await $`${runtime} build/cli.js test/fixtures/exit-code.mjs`.nothrow()
   assert.is(p.exitCode, 42)
 })
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import chalk from 'chalk'
-import { suite } from 'uvu'
+import { suite, isDeno } from '../test-util.js'
 import * as assert from 'uvu/assert'
 import process from 'node:process'
 import { inspect } from 'node:util'
@@ -22,7 +22,6 @@ import { Socket } from 'node:net'
 import { ProcessPromise, ProcessOutput } from '../build/index.js'
 import '../build/globals.js'
 
-const isDeno = typeof Deno !== 'undefined'
 const test = suite('core')
 
 $.verbose = false

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -15,12 +15,14 @@
 import chalk from 'chalk'
 import { suite } from 'uvu'
 import * as assert from 'uvu/assert'
+import process from 'node:process'
 import { inspect } from 'node:util'
 import { Writable } from 'node:stream'
 import { Socket } from 'node:net'
 import { ProcessPromise, ProcessOutput } from '../build/index.js'
 import '../build/globals.js'
 
+const isDeno = typeof Deno !== 'undefined'
 const test = suite('core')
 
 $.verbose = false
@@ -125,6 +127,7 @@ test('pipes are working', async () => {
 })
 
 test('ProcessPromise', async () => {
+  if (isDeno) return
   let contents = ''
   let stream = new Writable({
     write: function (chunk, encoding, next) {
@@ -198,6 +201,7 @@ test('cd() works with relative paths', async () => {
 })
 
 test('cd() does affect parallel contexts', async () => {
+  if (isDeno) return
   const cwd = process.cwd()
   try {
     fs.mkdirpSync('/tmp/zx-cd-parallel/one/two')
@@ -242,6 +246,7 @@ test('kill() method works', async () => {
 })
 
 test('a signal is passed with kill() method', async () => {
+  if (isDeno) return
   let p = $`while true; do :; done`
   setTimeout(() => p.kill('SIGKILL'), 100)
   let signal
@@ -254,6 +259,7 @@ test('a signal is passed with kill() method', async () => {
 })
 
 test('within() works', async () => {
+  if (isDeno) return
   let resolve, reject
   let promise = new Promise((...args) => ([resolve, reject] = args))
 
@@ -280,6 +286,7 @@ test('within() works', async () => {
 })
 
 test('within() restores previous cwd', async () => {
+  if (isDeno) return
   let resolve, reject
   let promise = new Promise((...args) => ([resolve, reject] = args))
 
@@ -299,6 +306,7 @@ test('within() restores previous cwd', async () => {
 })
 
 test(`within() isolates nested context and returns cb result`, async () => {
+  if (isDeno) return
   within(async () => {
     const res = await within(async () => {
       $.verbose = true
@@ -342,6 +350,7 @@ test('snapshots works', async () => {
 })
 
 test('timeout() works', async () => {
+  if (isDeno) return
   let exitCode, signal
   try {
     await $`sleep 9999`.timeout(10, 'SIGKILL')

--- a/test/deps.test.js
+++ b/test/deps.test.js
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { suite } from 'uvu'
+import { suite, isDeno, runtime } from '../test-util.js'
 import * as assert from 'uvu/assert'
 import { $ } from '../build/index.js'
 import { installDeps, parseDeps } from '../build/deps.js'
 
-const isDeno = typeof Deno !== 'undefined'
-const runtime = isDeno ? ['deno', 'run', '-A'] : 'node'
 const test = suite('deps')
 
 $.verbose = false

--- a/test/deps.test.js
+++ b/test/deps.test.js
@@ -17,11 +17,14 @@ import * as assert from 'uvu/assert'
 import { $ } from '../build/index.js'
 import { installDeps, parseDeps } from '../build/deps.js'
 
+const isDeno = typeof Deno !== 'undefined'
+const runtime = isDeno ? ['deno', 'run', '-A'] : 'node'
 const test = suite('deps')
 
 $.verbose = false
 
 test('installDeps() loader works via JS API', async () => {
+  if (isDeno) return
   await installDeps({
     cpy: '9.0.1',
     'lodash-es': '4.17.21',
@@ -31,8 +34,9 @@ test('installDeps() loader works via JS API', async () => {
 })
 
 test('installDeps() loader works via CLI', async () => {
+  if (isDeno) return
   let out =
-    await $`node build/cli.js --install <<< 'import _ from "lodash" /* @4.17.15 */; console.log(_.VERSION)'`
+    await $`${runtime} build/cli.js --install <<< 'import _ from "lodash" /* @4.17.15 */; console.log(_.VERSION)'`
   assert.match(out.stdout, '4.17.15')
 })
 
@@ -58,11 +62,11 @@ test('parseDeps(): multiline', () => {
   require('a') // @1.0.0
   const b =require('b') /* @2.0.0 */
   const c = {
-    c:require('c') /* @3.0.0 */, 
-    d: await import('d') /* @4.0.0 */, 
+    c:require('c') /* @3.0.0 */,
+    d: await import('d') /* @4.0.0 */,
     ...require('e') /* @5.0.0 */
   }
-  const f = [...require('f') /* @6.0.0 */] 
+  const f = [...require('f') /* @6.0.0 */]
   ;require('g'); // @7.0.0
   const h = 1 *require('h') // @8.0.0
   {require('i') /* @9.0.0 */}

--- a/test/extra.test.js
+++ b/test/extra.test.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import fs from 'node:fs'
-import { suite } from 'uvu'
+import { suite } from '../test-util.js'
 import * as assert from 'uvu/assert'
 import { globby } from 'globby'
 

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -29,7 +29,7 @@ test('global cd()', async () => {
 
 test('injects zx index to global', () => {
   for (let [key, value] of Object.entries(index)) {
-    assert.is(global[key], value)
+    assert.is(globalThis[key], value)
   }
 })
 

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { suite } from 'uvu'
+import { suite } from '../test-util.js'
 import * as assert from 'uvu/assert'
 import '../build/globals.js'
 import * as index from '../build/index.js'

--- a/test/goods.test.js
+++ b/test/goods.test.js
@@ -13,12 +13,10 @@
 // limitations under the License.
 
 import chalk from 'chalk'
-import { suite } from 'uvu'
+import { suite, isDeno, runtime } from '../test-util.js'
 import * as assert from 'uvu/assert'
 import '../build/globals.js'
 
-const isDeno = typeof Deno !== 'undefined'
-const runtime = isDeno ? ['deno', 'run', '-A'] : 'node'
 const test = suite('goods')
 
 $.verbose = false

--- a/test/goods.test.js
+++ b/test/goods.test.js
@@ -17,16 +17,19 @@ import { suite } from 'uvu'
 import * as assert from 'uvu/assert'
 import '../build/globals.js'
 
+const isDeno = typeof Deno !== 'undefined'
+const runtime = isDeno ? ['deno', 'run', '-A'] : 'node'
 const test = suite('goods')
 
 $.verbose = false
 
 function zx(script) {
-  return $`node build/cli.js --eval ${script}`.nothrow().timeout('5s')
+  return $`${runtime} build/cli.js --eval ${script}`.nothrow().timeout('5s')
 }
 
 test('question() works', async () => {
-  let p = $`node build/cli.js --eval "
+  if (isDeno) return
+  let p = $`${runtime} build/cli.js --eval "
   let answer = await question('foo or bar? ', { choices: ['foo', 'bar'] })
   echo('Answer is', answer)
 "`
@@ -48,6 +51,7 @@ test('globby available', async () => {
 })
 
 test('fetch() works', async () => {
+  if (isDeno) return
   assert.match(
     await fetch('https://medv.io').then((res) => res.text()),
     /Anton Medvedev/
@@ -137,6 +141,7 @@ test('spinner() with title works', async () => {
 })
 
 test('spinner() stops on throw', async () => {
+  if (isDeno) return
   let out = await zx(`
     await spinner('processing', () => $\`wtf-cmd\`)
   `)

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { suite } from 'uvu'
+import { suite, isDeno } from '../test-util.js'
 import * as assert from 'uvu/assert'
 import '../build/globals.js'
 
-const isDeno = typeof Deno !== 'undefined'
 const test = suite('package')
 
 test.before.each(async () => {

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -16,6 +16,7 @@ import { suite } from 'uvu'
 import * as assert from 'uvu/assert'
 import '../build/globals.js'
 
+const isDeno = typeof Deno !== 'undefined'
 const test = suite('package')
 
 test.before.each(async () => {
@@ -26,6 +27,7 @@ test.before.each(async () => {
 })
 
 test('ts project', async () => {
+  if (isDeno) return
   const pack = path.resolve('package')
   const out = await within(async () => {
     cd('test/fixtures/ts-project')
@@ -43,6 +45,7 @@ test('ts project', async () => {
 })
 
 test('js project with zx', async () => {
+  if (isDeno) return
   const pack = path.resolve('package')
   const out = await within(async () => {
     cd('test/fixtures/js-project')

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { suite } from 'uvu'
+import { suite } from '../test-util.js'
 import * as assert from 'uvu/assert'
 import {
   exitCodeInfo,

--- a/test/win32.test.js
+++ b/test/win32.test.js
@@ -14,6 +14,7 @@
 
 import { suite } from 'uvu'
 import * as assert from 'uvu/assert'
+import process from 'node:process'
 import '../build/globals.js'
 
 const test = suite('win32')

--- a/test/win32.test.js
+++ b/test/win32.test.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { suite } from 'uvu'
+import { suite } from '../test-util.js'
 import * as assert from 'uvu/assert'
 import process from 'node:process'
 import '../build/globals.js'


### PR DESCRIPTION
- [x] Tests pass (?)
- [ ] Appropriate changes to README are included in PR
- [ ] Types updated

- Add GitHub Actions workflow for Deno tests
- Improve Deno compatibility

  This is mostly adding imports for globals (`process`, `setImmediate`) and replacing `global` with `globalThis`.

  One particular change is to import `node:repl` asynchronously because Deno currently does not support it. Have it in the top scope would affect other files that import it but not actually use it.

  Note: these changes are for _testing_ zx, not necessarily for _using_ zx. Running `npm:zx` in Deno has additional compat assurance I'm still comprehending.

- Adapt tests to Deno

  This is actually quite complicated as the tests are effectively testing both the project (zx) code _and_ Deno's Node compatibility code. Quite a few tests doesn't pass for the moment, for now they are skipped (`if (isDeno) return`):

  - Tests using `within()`
  - Tests changing status code or passing signals
  - Tests using `node:repl`
  - Tests mess with `package.json` dependencies which is not a thing in Deno
  - Some other stuff

  Tests are run with `Deno.test()` because the way uvu imports tests doesn't work under Deno's Node compat mode.