### PR TITLE
Remove unnecessary "moduleResolution" property from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "ES2021",
     "lib": ["ES2021", "DOM"],
-    "moduleResolution": "NodeNext",
     "module": "NodeNext",
     "strict": true,
     "outDir": "./build",


### PR DESCRIPTION
This PR removes the "moduleResolution": "NodeNext" property from the tsconfig.json file. Since we already have "module": "NodeNext" set, the TypeScript compiler will automatically use the appropriate module resolution strategy for Node.js ESM. Therefore, the "moduleResolution" property is redundant and can be removed to simplify the configuration.