### PR TITLE
shell polyglot support: extract code from start/end markers for javascript embedded in shell scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,15 @@ in **package.json**
 and [`"module": "ESNext"`](https://www.typescriptlang.org/tsconfig/#module)
 in **tsconfig.json**.
 
+### Javascript embedded within other scripts
+
+The `zx` can execute code embedded in arbitrary text (i.e. shell scripts) using the special delimeters
+`~~~~~zx start~~~~~` and `~~~~~zx end~~~~~`. This can be used to create scripts that can auto install node or
+zx itself making script execution truely painless. See [example](examples/self-install)
+
+```bash
+zx examples/self-install
+```
 ### Executing remote scripts
 
 If the argument to the `zx` executable starts with `https://`, the file will be

--- a/examples/self-install
+++ b/examples/self-install
@@ -1,0 +1,45 @@
+#!/bin/bash
+if [ "bash" = "$0" ]; then
+    # Instructors for your users: 
+    # If self-install.sh is hosted on example.org, instruct your users to install the script via
+    # curl https://example.com/self-install | bash
+    # 
+    # Instructions for you: 
+    # Do some installation here... (yes, this downloads the script twice since its not possible to 
+    # access the script source in bash) 
+    #
+    # curl https://example.com/self-install -o /usr/local/bin/self-install
+    # chmod +x /usr/local/bin/self-install
+    echo "Installed!"
+    exit 0
+fi
+if ! command -v node &> /dev/null; then
+    echo "The javascript runtime 'node' is required but it is not installed."
+    printf "Should I install volta, a package manager, and node, a javascript runtime? (y/n)?"
+    read answer
+    if [ "$answer" != "${answer#[Yy]}" ] ;then 
+        curl -s https://get.volta.sh | bash
+        volta install node
+    else
+        echo 'Aborting - make sure you have node installed and try again'
+        exit 1
+    fi
+fi
+if ! command -v zx &> /dev/null; then
+    echo "This script ($0) requires zx but it is not installed"
+    printf "Should I zx globally via npm? (y/n)?"
+    read answer
+    if [ "$answer" != "${answer#[Yy]}" ] ;then 
+        npm --no-fund install -g zx
+    else
+        echo 'Aborting - zx is required'
+        exit 1
+    fi
+fi
+# The special zx start and zx end delimeters are necessary so the script can be executed either by bash
+# or by zx
+zx << 'EOF'
+~~~~~zx start~~~~~
+console.log("Script execution a success!")
+~~~~~zx end~~~~~
+EOF

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,6 +108,17 @@ async function runScript(script: string) {
   await writeAndImport(script, filepath)
 }
 
+function extractScript(script: string | Buffer) {
+  const startMarker = '~~~~~zx start~~~~~'
+  const endMarker = '~~~~~zx end~~~~~'
+  const source = script.toString()
+  const sIdx = source.indexOf(startMarker)
+  if (sIdx == -1) return source
+  const eIdx = source.lastIndexOf(endMarker)
+  if (eIdx == -1) return source
+  return source.substring(sIdx + startMarker.length, eIdx)
+}
+
 async function scriptFromStdin() {
   let script = ''
   if (!process.stdin.isTTY) {
@@ -115,7 +126,7 @@ async function scriptFromStdin() {
     for await (const chunk of process.stdin) {
       script += chunk
     }
-
+    script = extractScript(script)
     if (script.length > 0) {
       await runScript(script)
       return true
@@ -130,7 +141,7 @@ async function scriptFromHttp(remote: string) {
     console.error(`Error: Can't get ${remote}`)
     process.exit(1)
   }
-  const script = await res.text()
+  const script = extractScript(await res.text())
   const pathname = new URL(remote).pathname
   const name = basename(pathname)
   const ext = extname(pathname) || '.mjs'
@@ -160,7 +171,7 @@ async function importPath(filepath: string, origin = filepath) {
       : `${basename(filepath)}.mjs`
 
     return writeAndImport(
-      await fs.readFile(filepath),
+      extractScript(await fs.readFile(filepath)),
       join(dirname(filepath), tmpFilename),
       origin
     )

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -130,8 +130,7 @@ test('script start/end markers working for stdin', async () => {
 })
 
 test('script start/end markers working for file', async () => {
-  let out =
-    await $`node build/cli.js test/fixtures/start-end-markers`
+  let out = await $`node build/cli.js test/fixtures/start-end-markers`
   assert.match(out.stdout, 'Script execution a success!')
 })
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -123,6 +123,24 @@ test('require() is working from stdin', async () => {
   assert.match(out.stdout, 'zx')
 })
 
+test('script start/end markers working for stdin', async () => {
+  let out =
+    await $`node build/cli.js <<< 'not\na\nscript\n ~~~~~zx start~~~~~\nconsole.log(require("./package.json").name)\n~~~~~zx end~~~~~\nnot\na\nscript\n'`
+  assert.match(out.stdout, 'zx')
+})
+
+test('script start/end markers working for file', async () => {
+  let out =
+    await $`node build/cli.js test/fixtures/start-end-markers`
+  assert.match(out.stdout, 'Script execution a success!')
+})
+
+test('script start/end markers working for http', async () => {
+  $`cat ${path.resolve('test/fixtures/start-end-markers.http')} | nc -l 8082`
+  let out = await $`node build/cli.js http://127.0.0.1:8082/start-end-markers`
+  assert.match(out.stdout, 'Script execution a success!')
+})
+
 test('require() is working in ESM', async () => {
   await $`node build/cli.js test/fixtures/require.mjs`
 })

--- a/test/fixtures/start-end-markers
+++ b/test/fixtures/start-end-markers
@@ -1,0 +1,8 @@
+#!/bin/sh
+# The special zx start and zx end delimeters are necessary so the script can be executed either by bash
+# or by zx
+zx << 'EOF'
+~~~~~zx start~~~~~
+console.log("Script execution a success!")
+~~~~~zx end~~~~~
+EOF

--- a/test/fixtures/start-end-markers.http
+++ b/test/fixtures/start-end-markers.http
@@ -1,0 +1,10 @@
+HTTP/1.1 200 OK
+
+#!/bin/sh
+# The special zx start and zx end delimeters are necessary so the script can be executed either by bash
+# or by zx
+zx << 'EOF'
+~~~~~zx start~~~~~
+console.log("Script execution a success!")
+~~~~~zx end~~~~~
+EOF


### PR DESCRIPTION

Fixes #631 
A new feature: allow zx to extract code delimited by `~~~~~zx start~~~~~` and `~~~~~zx end~~~~~` so that you can wrap a `zx` script with a shell script to install things like `node`, `zx` itself, or any other pre-run tasks (installation/auto-update, etc)

See [example](examples/self-install)


> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
- [x] Types updated
