### PR TITLE
docs: fix example for within function

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,11 +233,15 @@ await $`pwd` // => /home/path
 ```
 
 ```js
+await $`node --version` // => v20.2.0
+
 let version = await within(async () => {
-  $.prefix += 'export NVM_DIR=$HOME/.nvm; source $NVM_DIR/nvm.sh; '
-  await $`nvm use 16`
-  return $`node -v`
+  $.prefix += 'export NVM_DIR=$HOME/.nvm; source $NVM_DIR/nvm.sh; nvm use 16;'
+  
+  return $`node --version`
 })
+
+echo(version) // => v16.20.0
 ```
 
 ### `retry()`


### PR DESCRIPTION
I struggled with switching Node.js version via [nvm](https://github.com/nvm-sh/nvm) in my `zx` script because docs are misleading currently - `nvm use 16` must be part of prefix to allow using Node.js 16 inside the context

I found fix was provided in #362 but docs are incorrect


- [x] Appropriate changes to README are included in PR

---

# Example

## Current version 

```js
await $`node --version`

let version = await within(async () => {
    $.prefix += 'export NVM_DIR=$HOME/.nvm; source $NVM_DIR/nvm.sh;'

    await $`nvm use 16`

    return $`node --version`
})

echo(version);
```

```
$ node --version
v20.2.0
$ nvm use 16 <--- switching to version 16
Now using node v16.20.0 (npm v8.19.4)
$ node --version
v20.2.0 <---- but still 20 is used
v20.2.0
```

## Fixed version

```js
await $`node --version`

let version = await within(async () => {
    $.prefix += 'export NVM_DIR=$HOME/.nvm; source $NVM_DIR/nvm.sh; nvm use 16;'

    return $`node --version`
})

echo(version);
```

```
$ node --version
v20.2.0
$ node --version
Now using node v16.20.0 (npm v8.19.4)
v16.20.0 <---- it's actually 16 here
Now using node v16.20.0 (npm v8.19.4)
v16.20.0
```