### PR TITLE
Add an await on the npm install command

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -27,7 +27,7 @@ export async function installDeps(
     return
   }
   await spinner(`npm i ${packages.join(' ')}`, () =>
-    $`npm install --no-save --no-audit --no-fund ${flags} ${packages}`.nothrow()
+    await $`npm install --no-save --no-audit --no-fund ${flags} ${packages}`.nothrow()
   )
 }
 


### PR DESCRIPTION
So that the script is executed after the install is done.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
- [ ] Types updated
