### PR TITLE
fix(argv): exclude script filename from argv

### DIFF
--- a/src/goods.ts
+++ b/src/goods.ts
@@ -30,7 +30,7 @@ export { default as path } from 'node:path'
 export { default as os } from 'node:os'
 export { ssh } from 'webpod'
 
-export let argv = minimist(process.argv.slice(2))
+export let argv = minimist(process.argv.slice(3))
 export function updateArgv(args: string[]) {
   argv = minimist(args)
   ;(global as any).argv = argv


### PR DESCRIPTION
Issue #701

I tried filtering the basename.