### PR TITLE
refactor: separate core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "zurk": "^0.0.9"
+        "zurk": "^0.0.11"
       },
       "bin": {
         "zx": "build/cli.js"
@@ -6840,9 +6840,9 @@
       }
     },
     "node_modules/zurk": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.9.tgz",
-      "integrity": "sha512-6AYDIzvTgyEk0gVgrS3VY4SrI4RkJWqvYwpFFh4kKarfZH1uWBqffQFRHcO60LR7tRhb8tpD5hfrVid2Mhx1uA=="
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.11.tgz",
+      "integrity": "sha512-MUDnizKKYW2VagxH7yIG5FxBXNuKzGeb/oqRke/ZtNxLVHDpz07gGW28fOEwNBA/5WSuJryNWXcx0lN8OVj0aA=="
     }
   },
   "dependencies": {
@@ -11679,9 +11679,9 @@
       "dev": true
     },
     "zurk": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.9.tgz",
-      "integrity": "sha512-6AYDIzvTgyEk0gVgrS3VY4SrI4RkJWqvYwpFFh4kKarfZH1uWBqffQFRHcO60LR7tRhb8tpD5hfrVid2Mhx1uA=="
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.11.tgz",
+      "integrity": "sha512-MUDnizKKYW2VagxH7yIG5FxBXNuKzGeb/oqRke/ZtNxLVHDpz07gGW28fOEwNBA/5WSuJryNWXcx0lN8OVj0aA=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "zurk": "^0.0.4"
+        "zurk": "^0.0.6"
       },
       "bin": {
         "zx": "build/cli.js"
@@ -6840,9 +6840,9 @@
       }
     },
     "node_modules/zurk": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.4.tgz",
-      "integrity": "sha512-VZOH2Drh4cnS7CtF5A7Ej+31Uz+zZsYF/BKaEX5VMlvx56EWib6ZyYCVG3b5TL94b85VDIU2Uv+hN0KSXmWJRw=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.6.tgz",
+      "integrity": "sha512-Vl+sHXA0W9uVKJo4xOQ2yUHVLETIuGLH18OPGHtgM7JhbWX1/TxWRhstG+LnmBAJAR9WhrjCbmtxlXX/9KJyLg=="
     }
   },
   "dependencies": {
@@ -11679,9 +11679,9 @@
       "dev": true
     },
     "zurk": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.4.tgz",
-      "integrity": "sha512-VZOH2Drh4cnS7CtF5A7Ej+31Uz+zZsYF/BKaEX5VMlvx56EWib6ZyYCVG3b5TL94b85VDIU2Uv+hN0KSXmWJRw=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.6.tgz",
+      "integrity": "sha512-Vl+sHXA0W9uVKJo4xOQ2yUHVLETIuGLH18OPGHtgM7JhbWX1/TxWRhstG+LnmBAJAR9WhrjCbmtxlXX/9KJyLg=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
         "c8": "^7.13.0",
         "chalk": "^5.3.0",
         "dts-bundle-generator": "^9.3.1",
-        "esbuild": "^0.20.1",
+        "esbuild": "^0.20.2",
         "esbuild-node-externals": "^1.13.0",
-        "esbuild-plugin-entry-chunks": "^0.1.8",
+        "esbuild-plugin-entry-chunks": "^0.1.11",
         "fs-extra": "^11.2.0",
         "fx": "*",
         "globby": "^14.0.1",
@@ -37,14 +37,14 @@
         "webpod": "^0",
         "which": "^3.0.0",
         "yaml": "^2.3.4",
-        "zurk": "^0.0.26"
+        "zurk": "^0.0.27"
       },
       "engines": {
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
         "@types/fs-extra": "^11.0.4",
-        "@types/node": ">=20.11.19"
+        "@types/node": ">=20.11.28"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -798,9 +798,9 @@
       "dev": true
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.1.tgz",
-      "integrity": "sha512-m55cpeupQ2DbuRGQMMZDzbv9J9PgVelPjlcmM5kxHnrBdBx6REaEd7LamYV7Dm8N7rCyR/XwU6rVP8ploKtIkA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
       "cpu": [
         "ppc64"
       ],
@@ -814,9 +814,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.1.tgz",
-      "integrity": "sha512-4j0+G27/2ZXGWR5okcJi7pQYhmkVgb4D7UKwxcqrjhvp5TKWx3cUjgB1CGj1mfdmJBQ9VnUGgUhign+FPF2Zgw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
       "cpu": [
         "arm"
       ],
@@ -830,9 +830,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.1.tgz",
-      "integrity": "sha512-hCnXNF0HM6AjowP+Zou0ZJMWWa1VkD77BXe959zERgGJBBxB+sV+J9f/rcjeg2c5bsukD/n17RKWXGFCO5dD5A==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
       "cpu": [
         "arm64"
       ],
@@ -846,9 +846,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.1.tgz",
-      "integrity": "sha512-MSfZMBoAsnhpS+2yMFYIQUPs8Z19ajwfuaSZx+tSl09xrHZCjbeXXMsUF/0oq7ojxYEpsSo4c0SfjxOYXRbpaA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
       "cpu": [
         "x64"
       ],
@@ -862,9 +862,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.1.tgz",
-      "integrity": "sha512-Ylk6rzgMD8klUklGPzS414UQLa5NPXZD5tf8JmQU8GQrj6BrFA/Ic9tb2zRe1kOZyCbGl+e8VMbDRazCEBqPvA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
       "cpu": [
         "arm64"
       ],
@@ -878,9 +878,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.1.tgz",
-      "integrity": "sha512-pFIfj7U2w5sMp52wTY1XVOdoxw+GDwy9FsK3OFz4BpMAjvZVs0dT1VXs8aQm22nhwoIWUmIRaE+4xow8xfIDZA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
       "cpu": [
         "x64"
       ],
@@ -894,9 +894,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.1.tgz",
-      "integrity": "sha512-UyW1WZvHDuM4xDz0jWun4qtQFauNdXjXOtIy7SYdf7pbxSWWVlqhnR/T2TpX6LX5NI62spt0a3ldIIEkPM6RHw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
       "cpu": [
         "arm64"
       ],
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.1.tgz",
-      "integrity": "sha512-itPwCw5C+Jh/c624vcDd9kRCCZVpzpQn8dtwoYIt2TJF3S9xJLiRohnnNrKwREvcZYx0n8sCSbvGH349XkcQeg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
       "cpu": [
         "x64"
       ],
@@ -926,9 +926,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.1.tgz",
-      "integrity": "sha512-LojC28v3+IhIbfQ+Vu4Ut5n3wKcgTu6POKIHN9Wpt0HnfgUGlBuyDDQR4jWZUZFyYLiz4RBBBmfU6sNfn6RhLw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
       "cpu": [
         "arm"
       ],
@@ -942,9 +942,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.1.tgz",
-      "integrity": "sha512-cX8WdlF6Cnvw/DO9/X7XLH2J6CkBnz7Twjpk56cshk9sjYVcuh4sXQBy5bmTwzBjNVZze2yaV1vtcJS04LbN8w==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
       "cpu": [
         "arm64"
       ],
@@ -958,9 +958,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.1.tgz",
-      "integrity": "sha512-4H/sQCy1mnnGkUt/xszaLlYJVTz3W9ep52xEefGtd6yXDQbz/5fZE5dFLUgsPdbUOQANcVUa5iO6g3nyy5BJiw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
       "cpu": [
         "ia32"
       ],
@@ -974,9 +974,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.1.tgz",
-      "integrity": "sha512-c0jgtB+sRHCciVXlyjDcWb2FUuzlGVRwGXgI+3WqKOIuoo8AmZAddzeOHeYLtD+dmtHw3B4Xo9wAUdjlfW5yYA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
       "cpu": [
         "loong64"
       ],
@@ -990,9 +990,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.1.tgz",
-      "integrity": "sha512-TgFyCfIxSujyuqdZKDZ3yTwWiGv+KnlOeXXitCQ+trDODJ+ZtGOzLkSWngynP0HZnTsDyBbPy7GWVXWaEl6lhA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
       "cpu": [
         "mips64el"
       ],
@@ -1006,9 +1006,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.1.tgz",
-      "integrity": "sha512-b+yuD1IUeL+Y93PmFZDZFIElwbmFfIKLKlYI8M6tRyzE6u7oEP7onGk0vZRh8wfVGC2dZoy0EqX1V8qok4qHaw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
       "cpu": [
         "ppc64"
       ],
@@ -1022,9 +1022,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.1.tgz",
-      "integrity": "sha512-wpDlpE0oRKZwX+GfomcALcouqjjV8MIX8DyTrxfyCfXxoKQSDm45CZr9fanJ4F6ckD4yDEPT98SrjvLwIqUCgg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
       "cpu": [
         "riscv64"
       ],
@@ -1038,9 +1038,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.1.tgz",
-      "integrity": "sha512-5BepC2Au80EohQ2dBpyTquqGCES7++p7G+7lXe1bAIvMdXm4YYcEfZtQrP4gaoZ96Wv1Ute61CEHFU7h4FMueQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
       "cpu": [
         "s390x"
       ],
@@ -1054,9 +1054,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.1.tgz",
-      "integrity": "sha512-5gRPk7pKuaIB+tmH+yKd2aQTRpqlf1E4f/mC+tawIm/CGJemZcHZpp2ic8oD83nKgUPMEd0fNanrnFljiruuyA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
       "cpu": [
         "x64"
       ],
@@ -1070,9 +1070,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.1.tgz",
-      "integrity": "sha512-4fL68JdrLV2nVW2AaWZBv3XEm3Ae3NZn/7qy2KGAt3dexAgSVT+Hc97JKSZnqezgMlv9x6KV0ZkZY7UO5cNLCg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
       "cpu": [
         "x64"
       ],
@@ -1086,9 +1086,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.1.tgz",
-      "integrity": "sha512-GhRuXlvRE+twf2ES+8REbeCb/zeikNqwD3+6S5y5/x+DYbAQUNl0HNBs4RQJqrechS4v4MruEr8ZtAin/hK5iw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
       "cpu": [
         "x64"
       ],
@@ -1102,9 +1102,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.1.tgz",
-      "integrity": "sha512-ZnWEyCM0G1Ex6JtsygvC3KUUrlDXqOihw8RicRuQAzw+c4f1D66YlPNNV3rkjVW90zXVsHwZYWbJh3v+oQFM9Q==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
       "cpu": [
         "x64"
       ],
@@ -1118,9 +1118,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.1.tgz",
-      "integrity": "sha512-QZ6gXue0vVQY2Oon9WyLFCdSuYbXSoxaZrPuJ4c20j6ICedfsDilNPYfHLlMH7vGfU5DQR0czHLmJvH4Nzis/A==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
       "cpu": [
         "arm64"
       ],
@@ -1134,9 +1134,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.1.tgz",
-      "integrity": "sha512-HzcJa1NcSWTAU0MJIxOho8JftNp9YALui3o+Ny7hCh0v5f90nprly1U3Sj1Ldj/CvKKdvvFsCRvDkpsEMp4DNw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
       "cpu": [
         "ia32"
       ],
@@ -1150,9 +1150,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.1.tgz",
-      "integrity": "sha512-0MBh53o6XtI6ctDnRMeQ+xoCN8kD2qI1rY1KgF/xdWQwoFeKou7puvDfV8/Wv4Ctx2rRpET/gGdz3YlNtNACSA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
       "cpu": [
         "x64"
       ],
@@ -2668,9 +2668,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.1.tgz",
-      "integrity": "sha512-OJwEgrpWm/PCMsLVWXKqvcjme3bHNpOgN7Tb6cQnR5n0TPbQx1/Xrn7rqM+wn17bYeT6MGB5sn1Bh5YiGi70nA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -2680,29 +2680,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.20.1",
-        "@esbuild/android-arm": "0.20.1",
-        "@esbuild/android-arm64": "0.20.1",
-        "@esbuild/android-x64": "0.20.1",
-        "@esbuild/darwin-arm64": "0.20.1",
-        "@esbuild/darwin-x64": "0.20.1",
-        "@esbuild/freebsd-arm64": "0.20.1",
-        "@esbuild/freebsd-x64": "0.20.1",
-        "@esbuild/linux-arm": "0.20.1",
-        "@esbuild/linux-arm64": "0.20.1",
-        "@esbuild/linux-ia32": "0.20.1",
-        "@esbuild/linux-loong64": "0.20.1",
-        "@esbuild/linux-mips64el": "0.20.1",
-        "@esbuild/linux-ppc64": "0.20.1",
-        "@esbuild/linux-riscv64": "0.20.1",
-        "@esbuild/linux-s390x": "0.20.1",
-        "@esbuild/linux-x64": "0.20.1",
-        "@esbuild/netbsd-x64": "0.20.1",
-        "@esbuild/openbsd-x64": "0.20.1",
-        "@esbuild/sunos-x64": "0.20.1",
-        "@esbuild/win32-arm64": "0.20.1",
-        "@esbuild/win32-ia32": "0.20.1",
-        "@esbuild/win32-x64": "0.20.1"
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
       }
     },
     "node_modules/esbuild-node-externals": {
@@ -2722,9 +2722,9 @@
       }
     },
     "node_modules/esbuild-plugin-entry-chunks": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/esbuild-plugin-entry-chunks/-/esbuild-plugin-entry-chunks-0.1.8.tgz",
-      "integrity": "sha512-iKX18Uj8WTiRygwOGNa4S66pvNeexcvH1ohs/P5wV0fVGCRRzHzCiyI1/HShCVkC8HOnxvGWiG006PmsBHmS9Q==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-entry-chunks/-/esbuild-plugin-entry-chunks-0.1.11.tgz",
+      "integrity": "sha512-lSFwPa7YYdp0iSg3ukKKlHrJ735WpsqlkfsYzUHXYhFYRHPuYaf5qkNyWulyDL7ycPlguCo/Q4ALCsi1mu6waA==",
       "dev": true,
       "dependencies": {
         "depseek": "0.4.0"
@@ -6838,9 +6838,9 @@
       }
     },
     "node_modules/zurk": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.26.tgz",
-      "integrity": "sha512-/Rtc4/8dbpyT9mLbRA0NqszPHnIsgCRhp3MSYQOJShEuNkCehH6VnYxhsTbFPFgbGDXJannKTLZsun8FkwwpPg==",
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.27.tgz",
+      "integrity": "sha512-BwvvxnPmiiI0H8ThWj7XSUrMN33X/JTb+qiA7/2M03jwwFtCGPwDxpNzKbI9aNKRkJu1v6XD73Y5aYY+eNyGSg==",
       "dev": true
     }
   },
@@ -7402,163 +7402,163 @@
       "dev": true
     },
     "@esbuild/aix-ppc64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.1.tgz",
-      "integrity": "sha512-m55cpeupQ2DbuRGQMMZDzbv9J9PgVelPjlcmM5kxHnrBdBx6REaEd7LamYV7Dm8N7rCyR/XwU6rVP8ploKtIkA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
       "dev": true,
       "optional": true
     },
     "@esbuild/android-arm": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.1.tgz",
-      "integrity": "sha512-4j0+G27/2ZXGWR5okcJi7pQYhmkVgb4D7UKwxcqrjhvp5TKWx3cUjgB1CGj1mfdmJBQ9VnUGgUhign+FPF2Zgw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
       "dev": true,
       "optional": true
     },
     "@esbuild/android-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.1.tgz",
-      "integrity": "sha512-hCnXNF0HM6AjowP+Zou0ZJMWWa1VkD77BXe959zERgGJBBxB+sV+J9f/rcjeg2c5bsukD/n17RKWXGFCO5dD5A==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/android-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.1.tgz",
-      "integrity": "sha512-MSfZMBoAsnhpS+2yMFYIQUPs8Z19ajwfuaSZx+tSl09xrHZCjbeXXMsUF/0oq7ojxYEpsSo4c0SfjxOYXRbpaA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/darwin-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.1.tgz",
-      "integrity": "sha512-Ylk6rzgMD8klUklGPzS414UQLa5NPXZD5tf8JmQU8GQrj6BrFA/Ic9tb2zRe1kOZyCbGl+e8VMbDRazCEBqPvA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/darwin-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.1.tgz",
-      "integrity": "sha512-pFIfj7U2w5sMp52wTY1XVOdoxw+GDwy9FsK3OFz4BpMAjvZVs0dT1VXs8aQm22nhwoIWUmIRaE+4xow8xfIDZA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.1.tgz",
-      "integrity": "sha512-UyW1WZvHDuM4xDz0jWun4qtQFauNdXjXOtIy7SYdf7pbxSWWVlqhnR/T2TpX6LX5NI62spt0a3ldIIEkPM6RHw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.1.tgz",
-      "integrity": "sha512-itPwCw5C+Jh/c624vcDd9kRCCZVpzpQn8dtwoYIt2TJF3S9xJLiRohnnNrKwREvcZYx0n8sCSbvGH349XkcQeg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.1.tgz",
-      "integrity": "sha512-LojC28v3+IhIbfQ+Vu4Ut5n3wKcgTu6POKIHN9Wpt0HnfgUGlBuyDDQR4jWZUZFyYLiz4RBBBmfU6sNfn6RhLw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.1.tgz",
-      "integrity": "sha512-cX8WdlF6Cnvw/DO9/X7XLH2J6CkBnz7Twjpk56cshk9sjYVcuh4sXQBy5bmTwzBjNVZze2yaV1vtcJS04LbN8w==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-ia32": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.1.tgz",
-      "integrity": "sha512-4H/sQCy1mnnGkUt/xszaLlYJVTz3W9ep52xEefGtd6yXDQbz/5fZE5dFLUgsPdbUOQANcVUa5iO6g3nyy5BJiw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-loong64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.1.tgz",
-      "integrity": "sha512-c0jgtB+sRHCciVXlyjDcWb2FUuzlGVRwGXgI+3WqKOIuoo8AmZAddzeOHeYLtD+dmtHw3B4Xo9wAUdjlfW5yYA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-mips64el": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.1.tgz",
-      "integrity": "sha512-TgFyCfIxSujyuqdZKDZ3yTwWiGv+KnlOeXXitCQ+trDODJ+ZtGOzLkSWngynP0HZnTsDyBbPy7GWVXWaEl6lhA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-ppc64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.1.tgz",
-      "integrity": "sha512-b+yuD1IUeL+Y93PmFZDZFIElwbmFfIKLKlYI8M6tRyzE6u7oEP7onGk0vZRh8wfVGC2dZoy0EqX1V8qok4qHaw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-riscv64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.1.tgz",
-      "integrity": "sha512-wpDlpE0oRKZwX+GfomcALcouqjjV8MIX8DyTrxfyCfXxoKQSDm45CZr9fanJ4F6ckD4yDEPT98SrjvLwIqUCgg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-s390x": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.1.tgz",
-      "integrity": "sha512-5BepC2Au80EohQ2dBpyTquqGCES7++p7G+7lXe1bAIvMdXm4YYcEfZtQrP4gaoZ96Wv1Ute61CEHFU7h4FMueQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.1.tgz",
-      "integrity": "sha512-5gRPk7pKuaIB+tmH+yKd2aQTRpqlf1E4f/mC+tawIm/CGJemZcHZpp2ic8oD83nKgUPMEd0fNanrnFljiruuyA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/netbsd-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.1.tgz",
-      "integrity": "sha512-4fL68JdrLV2nVW2AaWZBv3XEm3Ae3NZn/7qy2KGAt3dexAgSVT+Hc97JKSZnqezgMlv9x6KV0ZkZY7UO5cNLCg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/openbsd-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.1.tgz",
-      "integrity": "sha512-GhRuXlvRE+twf2ES+8REbeCb/zeikNqwD3+6S5y5/x+DYbAQUNl0HNBs4RQJqrechS4v4MruEr8ZtAin/hK5iw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/sunos-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.1.tgz",
-      "integrity": "sha512-ZnWEyCM0G1Ex6JtsygvC3KUUrlDXqOihw8RicRuQAzw+c4f1D66YlPNNV3rkjVW90zXVsHwZYWbJh3v+oQFM9Q==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.1.tgz",
-      "integrity": "sha512-QZ6gXue0vVQY2Oon9WyLFCdSuYbXSoxaZrPuJ4c20j6ICedfsDilNPYfHLlMH7vGfU5DQR0czHLmJvH4Nzis/A==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-ia32": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.1.tgz",
-      "integrity": "sha512-HzcJa1NcSWTAU0MJIxOho8JftNp9YALui3o+Ny7hCh0v5f90nprly1U3Sj1Ldj/CvKKdvvFsCRvDkpsEMp4DNw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.1.tgz",
-      "integrity": "sha512-0MBh53o6XtI6ctDnRMeQ+xoCN8kD2qI1rY1KgF/xdWQwoFeKou7puvDfV8/Wv4Ctx2rRpET/gGdz3YlNtNACSA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
       "dev": true,
       "optional": true
     },
@@ -8683,34 +8683,34 @@
       }
     },
     "esbuild": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.1.tgz",
-      "integrity": "sha512-OJwEgrpWm/PCMsLVWXKqvcjme3bHNpOgN7Tb6cQnR5n0TPbQx1/Xrn7rqM+wn17bYeT6MGB5sn1Bh5YiGi70nA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
       "dev": true,
       "requires": {
-        "@esbuild/aix-ppc64": "0.20.1",
-        "@esbuild/android-arm": "0.20.1",
-        "@esbuild/android-arm64": "0.20.1",
-        "@esbuild/android-x64": "0.20.1",
-        "@esbuild/darwin-arm64": "0.20.1",
-        "@esbuild/darwin-x64": "0.20.1",
-        "@esbuild/freebsd-arm64": "0.20.1",
-        "@esbuild/freebsd-x64": "0.20.1",
-        "@esbuild/linux-arm": "0.20.1",
-        "@esbuild/linux-arm64": "0.20.1",
-        "@esbuild/linux-ia32": "0.20.1",
-        "@esbuild/linux-loong64": "0.20.1",
-        "@esbuild/linux-mips64el": "0.20.1",
-        "@esbuild/linux-ppc64": "0.20.1",
-        "@esbuild/linux-riscv64": "0.20.1",
-        "@esbuild/linux-s390x": "0.20.1",
-        "@esbuild/linux-x64": "0.20.1",
-        "@esbuild/netbsd-x64": "0.20.1",
-        "@esbuild/openbsd-x64": "0.20.1",
-        "@esbuild/sunos-x64": "0.20.1",
-        "@esbuild/win32-arm64": "0.20.1",
-        "@esbuild/win32-ia32": "0.20.1",
-        "@esbuild/win32-x64": "0.20.1"
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
       }
     },
     "esbuild-node-externals": {
@@ -8724,9 +8724,9 @@
       }
     },
     "esbuild-plugin-entry-chunks": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/esbuild-plugin-entry-chunks/-/esbuild-plugin-entry-chunks-0.1.8.tgz",
-      "integrity": "sha512-iKX18Uj8WTiRygwOGNa4S66pvNeexcvH1ohs/P5wV0fVGCRRzHzCiyI1/HShCVkC8HOnxvGWiG006PmsBHmS9Q==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-entry-chunks/-/esbuild-plugin-entry-chunks-0.1.11.tgz",
+      "integrity": "sha512-lSFwPa7YYdp0iSg3ukKKlHrJ735WpsqlkfsYzUHXYhFYRHPuYaf5qkNyWulyDL7ycPlguCo/Q4ALCsi1mu6waA==",
       "dev": true,
       "requires": {
         "depseek": "0.4.0"
@@ -11678,9 +11678,9 @@
       "dev": true
     },
     "zurk": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.26.tgz",
-      "integrity": "sha512-/Rtc4/8dbpyT9mLbRA0NqszPHnIsgCRhp3MSYQOJShEuNkCehH6VnYxhsTbFPFgbGDXJannKTLZsun8FkwwpPg==",
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.27.tgz",
+      "integrity": "sha512-BwvvxnPmiiI0H8ThWj7XSUrMN33X/JTb+qiA7/2M03jwwFtCGPwDxpNzKbI9aNKRkJu1v6XD73Y5aYY+eNyGSg==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "zurk": "^0.0.6"
+        "zurk": "^0.0.9"
       },
       "bin": {
         "zx": "build/cli.js"
@@ -6840,9 +6840,9 @@
       }
     },
     "node_modules/zurk": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.6.tgz",
-      "integrity": "sha512-Vl+sHXA0W9uVKJo4xOQ2yUHVLETIuGLH18OPGHtgM7JhbWX1/TxWRhstG+LnmBAJAR9WhrjCbmtxlXX/9KJyLg=="
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.9.tgz",
+      "integrity": "sha512-6AYDIzvTgyEk0gVgrS3VY4SrI4RkJWqvYwpFFh4kKarfZH1uWBqffQFRHcO60LR7tRhb8tpD5hfrVid2Mhx1uA=="
     }
   },
   "dependencies": {
@@ -11679,9 +11679,9 @@
       "dev": true
     },
     "zurk": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.6.tgz",
-      "integrity": "sha512-Vl+sHXA0W9uVKJo4xOQ2yUHVLETIuGLH18OPGHtgM7JhbWX1/TxWRhstG+LnmBAJAR9WhrjCbmtxlXX/9KJyLg=="
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.9.tgz",
+      "integrity": "sha512-6AYDIzvTgyEk0gVgrS3VY4SrI4RkJWqvYwpFFh4kKarfZH1uWBqffQFRHcO60LR7tRhb8tpD5hfrVid2Mhx1uA=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "zurk": "^0.0.3"
+        "zurk": "^0.0.4"
       },
       "bin": {
         "zx": "build/cli.js"
@@ -6840,9 +6840,9 @@
       }
     },
     "node_modules/zurk": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.3.tgz",
-      "integrity": "sha512-yMCJYRsJFATrRa0XCb6hbfodTd0XPWAY8Grcz/CtBAjmdEhRbQ2UqF9Le+gbM2zPztyBRfjgrtaC0s2lIHQTzA=="
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.4.tgz",
+      "integrity": "sha512-VZOH2Drh4cnS7CtF5A7Ej+31Uz+zZsYF/BKaEX5VMlvx56EWib6ZyYCVG3b5TL94b85VDIU2Uv+hN0KSXmWJRw=="
     }
   },
   "dependencies": {
@@ -11679,9 +11679,9 @@
       "dev": true
     },
     "zurk": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.3.tgz",
-      "integrity": "sha512-yMCJYRsJFATrRa0XCb6hbfodTd0XPWAY8Grcz/CtBAjmdEhRbQ2UqF9Le+gbM2zPztyBRfjgrtaC0s2lIHQTzA=="
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.4.tgz",
+      "integrity": "sha512-VZOH2Drh4cnS7CtF5A7Ej+31Uz+zZsYF/BKaEX5VMlvx56EWib6ZyYCVG3b5TL94b85VDIU2Uv+hN0KSXmWJRw=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "zx",
       "version": "7.2.3",
       "license": "Apache-2.0",
-      "dependencies": {
-        "zurk": "^0.0.11"
-      },
       "bin": {
         "zx": "build/cli.js"
       },
@@ -39,7 +36,8 @@
         "typescript": "^5.0.4",
         "webpod": "^0",
         "which": "^3.0.0",
-        "yaml": "^2.3.4"
+        "yaml": "^2.3.4",
+        "zurk": "^0.0.12"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -6840,9 +6838,10 @@
       }
     },
     "node_modules/zurk": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.11.tgz",
-      "integrity": "sha512-MUDnizKKYW2VagxH7yIG5FxBXNuKzGeb/oqRke/ZtNxLVHDpz07gGW28fOEwNBA/5WSuJryNWXcx0lN8OVj0aA=="
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.12.tgz",
+      "integrity": "sha512-oKk/I00YdRPViqG0dPD5EpSgMIVvvPKTsLhWWHWPslVFWQPODJBvKunoqDc/zv1Vwow/efE2XSHfwal7gdLVBw==",
+      "dev": true
     }
   },
   "dependencies": {
@@ -11679,9 +11678,10 @@
       "dev": true
     },
     "zurk": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.11.tgz",
-      "integrity": "sha512-MUDnizKKYW2VagxH7yIG5FxBXNuKzGeb/oqRke/ZtNxLVHDpz07gGW28fOEwNBA/5WSuJryNWXcx0lN8OVj0aA=="
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.12.tgz",
+      "integrity": "sha512-oKk/I00YdRPViqG0dPD5EpSgMIVvvPKTsLhWWHWPslVFWQPODJBvKunoqDc/zv1Vwow/efE2XSHfwal7gdLVBw==",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "zx",
       "version": "7.2.3",
       "license": "Apache-2.0",
+      "dependencies": {
+        "zurk": "^0.0.3"
+      },
       "bin": {
         "zx": "build/cli.js"
       },
@@ -29,7 +32,6 @@
         "globby": "^14.0.1",
         "madge": "^6.1.0",
         "minimist": "^1.2.8",
-        "node-fetch": "3.3.2",
         "node-fetch-native": "^1.6.2",
         "prettier": "^2.8.8",
         "ps-tree": "^1.2.0",
@@ -2130,15 +2132,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/date-format": {
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
@@ -3091,29 +3084,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/figures": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
@@ -3240,18 +3210,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/from": {
@@ -4656,43 +4614,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-fetch-native": {
@@ -6758,15 +6679,6 @@
       "integrity": "sha512-V8X6hPIzY1juvrSVREmtRhK9AHn/8c2z8XxaibESU+jyG/RinZ9x9x6aw8qEuFAi7R6Kl/EWGbU2Yq/9u6TTjw==",
       "dev": true
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/webpod": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/webpod/-/webpod-0.0.2.tgz",
@@ -6926,6 +6838,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zurk": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.3.tgz",
+      "integrity": "sha512-yMCJYRsJFATrRa0XCb6hbfodTd0XPWAY8Grcz/CtBAjmdEhRbQ2UqF9Le+gbM2zPztyBRfjgrtaC0s2lIHQTzA=="
     }
   },
   "dependencies": {
@@ -8356,12 +8273,6 @@
         }
       }
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-      "dev": true
-    },
     "date-format": {
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
@@ -9072,16 +8983,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "figures": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
@@ -9172,15 +9073,6 @@
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "requires": {
-        "fetch-blob": "^3.1.2"
       }
     },
     "from": {
@@ -10185,23 +10077,6 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true
-    },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true
-    },
-    "node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      }
     },
     "node-fetch-native": {
       "version": "1.6.2",
@@ -11686,12 +11561,6 @@
       "integrity": "sha512-V8X6hPIzY1juvrSVREmtRhK9AHn/8c2z8XxaibESU+jyG/RinZ9x9x6aw8qEuFAi7R6Kl/EWGbU2Yq/9u6TTjw==",
       "dev": true
     },
-    "web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "dev": true
-    },
     "webpod": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/webpod/-/webpod-0.0.2.tgz",
@@ -11808,6 +11677,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zurk": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.3.tgz",
+      "integrity": "sha512-yMCJYRsJFATrRa0XCb6hbfodTd0XPWAY8Grcz/CtBAjmdEhRbQ2UqF9Le+gbM2zPztyBRfjgrtaC0s2lIHQTzA=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "webpod": "^0",
         "which": "^3.0.0",
         "yaml": "^2.3.4",
-        "zurk": "^0.0.12"
+        "zurk": "^0.0.26"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -6838,9 +6838,9 @@
       }
     },
     "node_modules/zurk": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.12.tgz",
-      "integrity": "sha512-oKk/I00YdRPViqG0dPD5EpSgMIVvvPKTsLhWWHWPslVFWQPODJBvKunoqDc/zv1Vwow/efE2XSHfwal7gdLVBw==",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.26.tgz",
+      "integrity": "sha512-/Rtc4/8dbpyT9mLbRA0NqszPHnIsgCRhp3MSYQOJShEuNkCehH6VnYxhsTbFPFgbGDXJannKTLZsun8FkwwpPg==",
       "dev": true
     }
   },
@@ -11678,9 +11678,9 @@
       "dev": true
     },
     "zurk": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.12.tgz",
-      "integrity": "sha512-oKk/I00YdRPViqG0dPD5EpSgMIVvvPKTsLhWWHWPslVFWQPODJBvKunoqDc/zv1Vwow/efE2XSHfwal7gdLVBw==",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.0.26.tgz",
+      "integrity": "sha512-/Rtc4/8dbpyT9mLbRA0NqszPHnIsgCRhp3MSYQOJShEuNkCehH6VnYxhsTbFPFgbGDXJannKTLZsun8FkwwpPg==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "optionalDependencies": {
     "@types/fs-extra": "^11.0.4",
-    "@types/node": ">=20.11.19"
+    "@types/node": ">=20.11.28"
   },
   "devDependencies": {
     "@stryker-mutator/core": "^6.4.2",
@@ -67,9 +67,9 @@
     "c8": "^7.13.0",
     "chalk": "^5.3.0",
     "dts-bundle-generator": "^9.3.1",
-    "esbuild": "^0.20.1",
+    "esbuild": "^0.20.2",
     "esbuild-node-externals": "^1.13.0",
-    "esbuild-plugin-entry-chunks": "^0.1.8",
+    "esbuild-plugin-entry-chunks": "^0.1.11",
     "fs-extra": "^11.2.0",
     "fx": "*",
     "globby": "^14.0.1",
@@ -83,7 +83,7 @@
     "webpod": "^0",
     "which": "^3.0.0",
     "yaml": "^2.3.4",
-    "zurk": "^0.0.26"
+    "zurk": "^0.0.27"
   },
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"

--- a/package.json
+++ b/package.json
@@ -100,6 +100,6 @@
   "author": "Anton Medvedev <anton@medv.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "zurk": "^0.0.6"
+    "zurk": "^0.0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,6 @@
   "author": "Anton Medvedev <anton@medv.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "zurk": "^0.0.9"
+    "zurk": "^0.0.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,6 @@
   "author": "Anton Medvedev <anton@medv.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "zurk": "^0.0.4"
+    "zurk": "^0.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "webpod": "^0",
     "which": "^3.0.0",
     "yaml": "^2.3.4",
-    "zurk": "^0.0.12"
+    "zurk": "^0.0.26"
   },
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "webpod": "^0",
     "which": "^3.0.0",
     "yaml": "^2.3.4",
-    "zurk": "^0.0.11"
+    "zurk": "^0.0.12"
   },
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"

--- a/package.json
+++ b/package.json
@@ -98,5 +98,8 @@
   },
   "repository": "google/zx",
   "author": "Anton Medvedev <anton@medv.io>",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {
+    "zurk": "^0.0.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,6 @@
   "author": "Anton Medvedev <anton@medv.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "zurk": "^0.0.3"
+    "zurk": "^0.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "typescript": "^5.0.4",
     "webpod": "^0",
     "which": "^3.0.0",
-    "yaml": "^2.3.4"
+    "yaml": "^2.3.4",
+    "zurk": "^0.0.11"
   },
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
@@ -98,8 +99,5 @@
   },
   "repository": "google/zx",
   "author": "Anton Medvedev <anton@medv.io>",
-  "license": "Apache-2.0",
-  "dependencies": {
-    "zurk": "^0.0.11"
-  }
+  "license": "Apache-2.0"
 }

--- a/scripts/build-dts.mjs
+++ b/scripts/build-dts.mjs
@@ -37,6 +37,7 @@ const entry = {
       '@types/minimist',
       '@types/ps-tree',
       '@types/which',
+      'zurk',
     ], // args['external-inlines'],
   },
   output: {

--- a/src/core.ts
+++ b/src/core.ts
@@ -210,7 +210,10 @@ export class ProcessPromise extends Promise<ProcessOutput> {
       on: {
         start: () => {
           if (self._timeout) {
-            const t = setTimeout(() => self.kill(self._timeoutSignal), self._timeout)
+            const t = setTimeout(
+              () => self.kill(self._timeoutSignal),
+              self._timeout
+            )
             self.finally(() => clearTimeout(t)).catch(noop)
           }
         },

--- a/src/core.ts
+++ b/src/core.ts
@@ -196,9 +196,13 @@ export class ProcessPromise extends Promise<ProcessOutput> {
     this._zurk = zurk$({
       cmd: $.prefix + this._command,
       get cwd() { return $.cwd ?? $[processCwd] },
-      get shell() { return typeof $.shell === 'string' ? $.shell : true },
+      get shell() {
+        console.log('!!!shell=', $.shell)
+        return typeof $.shell === 'string' ? $.shell : true
+      },
       get env() { return $.env },
       get spawn() { return $.spawn },
+      quote: <T>(v: T): T => v, // let zx handle quoting
       stdio: this._stdio as any,
       sync: false,
       nothrow: true,

--- a/src/core.ts
+++ b/src/core.ts
@@ -17,7 +17,11 @@ import { ChildProcess, spawn, StdioNull, StdioPipe } from 'node:child_process'
 import { AsyncLocalStorage, createHook } from 'node:async_hooks'
 import { Readable, Writable } from 'node:stream'
 import { inspect } from 'node:util'
-import { $ as zurk$, TShellResponse as TZurkShellResponse } from 'zurk'
+import {
+  $ as zurk$,
+  buildCmd,
+  TShellResponse as TZurkShellResponse,
+} from 'zurk'
 import {
   chalk,
   which,
@@ -106,17 +110,8 @@ export const $ = new Proxy<Shell & Options>(
     }
     let resolve: Resolve, reject: Resolve
     const promise = new ProcessPromise((...args) => ([resolve, reject] = args))
-    let cmd = pieces[0],
-      i = 0
-    while (i < args.length) {
-      let s
-      if (Array.isArray(args[i])) {
-        s = args[i].map((x: any) => $.quote(substitute(x))).join(' ')
-      } else {
-        s = $.quote(substitute(args[i]))
-      }
-      cmd += s + pieces[++i]
-    }
+    const cmd = buildCmd($.quote, pieces, args) as string
+
     promise._bind(cmd, from, resolve!, reject!, getStore())
     // Postpone run to allow promise configuration.
     setImmediate(() => promise.isHalted || promise.run())

--- a/src/core.ts
+++ b/src/core.ts
@@ -18,11 +18,9 @@ import { AsyncLocalStorage, createHook } from 'node:async_hooks'
 import { Readable, Writable } from 'node:stream'
 import { inspect } from 'node:util'
 import {
-  $ as zurk$,
+  TZurkShellResponse,
+  zurk$,
   buildCmd,
-  TShellResponse as TZurkShellResponse,
-} from 'zurk'
-import {
   chalk,
   which,
   type ChalkInstance,

--- a/src/core.ts
+++ b/src/core.ts
@@ -228,6 +228,7 @@ export class ProcessPromise extends Promise<ProcessOutput> {
     this._zurk.then(({ error, stdout, stderr, stdall, status, signal }) => {
       if (error) {
         const message = ProcessOutput.getErrorMessage(error, self._from)
+        // Should we enable this?
         // (nothrow ? self._resolve : self._reject)(
         self._reject(
           new ProcessOutput(null, null, stdout, stderr, stdall, message)

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,14 +21,14 @@ export { minimist, chalk, fs, which, YAML, ssh } from './vendor.js'
 export { type Duration, quote, quotePowerShell } from './util.js'
 
 /**
- *  @deprecated Use $.nothrow() instead.
+ *  @deprecated Use $`cmd`.nothrow() instead.
  */
 export function nothrow(promise: ProcessPromise) {
   return promise.nothrow()
 }
 
 /**
- * @deprecated Use $.quiet() instead.
+ * @deprecated Use $`cmd`.quiet() instead.
  */
 export function quiet(promise: ProcessPromise) {
   return promise.quiet()

--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -26,6 +26,12 @@ import * as yaml from 'yaml'
 import * as _fs from 'fs-extra'
 import type { fetch } from 'node-fetch-native'
 
+export {
+  $ as zurk$,
+  buildCmd,
+  TShellResponse as TZurkShellResponse,
+} from 'zurk'
+
 export { fetch as nodeFetch } from 'node-fetch-native'
 export type RequestInfo = Parameters<typeof fetch>[0]
 export type RequestInit = Parameters<typeof fetch>[1]

--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -27,10 +27,9 @@ import * as _fs from 'fs-extra'
 import type { fetch } from 'node-fetch-native'
 
 export {
-  $ as zurk$,
+  exec,
   buildCmd,
-  TShellResponse as TZurkShellResponse,
-} from 'zurk'
+} from 'zurk/spawn'
 
 export { fetch as nodeFetch } from 'node-fetch-native'
 export type RequestInfo = Parameters<typeof fetch>[0]

--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -26,10 +26,7 @@ import * as yaml from 'yaml'
 import * as _fs from 'fs-extra'
 import type { fetch } from 'node-fetch-native'
 
-export {
-  exec,
-  buildCmd,
-} from 'zurk/spawn'
+export { exec, buildCmd } from 'zurk/spawn'
 
 export { fetch as nodeFetch } from 'node-fetch-native'
 export type RequestInfo = Parameters<typeof fetch>[0]

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -378,7 +378,7 @@ describe('core', () => {
       signal = p.signal
     }
     assert.equal(exitCode, undefined)
-    assert.equal(signal, undefined)
+    assert.equal(signal, 'SIGTERM')
   })
 
   test('$ thrown as error', async () => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -383,7 +383,7 @@ describe('core', () => {
       signal = p.signal
     }
     assert.equal(exitCode, undefined)
-    assert.equal(signal, 'SIGTERM')
+    assert.equal(signal, undefined)
   })
 
   test('$ thrown as error', async () => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -124,6 +124,11 @@ describe('core', () => {
     }
   })
 
+  test('provides presets', async () => {
+    const $$ = $({ nothrow: true })
+    assert.equal((await $$`exit 1`).exitCode, 1)
+  })
+
   test('ProcessPromise', async () => {
     let contents = ''
     let stream = new Writable({

--- a/test/win32.test.js
+++ b/test/win32.test.js
@@ -27,7 +27,6 @@ _describe('win32', () => {
     const p = await $`echo $0` // Bash is first by default.
     assert.match(p.stdout, /bash/)
     await within(async () => {
-      $.prefix = ''
       $.shell = which.sync('powershell.exe')
       $.quote = quotePowerShell
       const p = await $`get-host`
@@ -37,7 +36,6 @@ _describe('win32', () => {
 
   test('quotePowerShell works', async () => {
     await within(async () => {
-      $.prefix = ''
       $.shell = which.sync('powershell.exe')
       $.quote = quotePowerShell
       const p = await $`echo ${`Windows 'rulez!'`}`

--- a/test/win32.test.js
+++ b/test/win32.test.js
@@ -27,6 +27,7 @@ _describe('win32', () => {
     const p = await $`echo $0` // Bash is first by default.
     assert.match(p.stdout, /bash/)
     await within(async () => {
+      $.prefix = ''
       $.shell = which.sync('powershell.exe')
       $.quote = quotePowerShell
       const p = await $`get-host`
@@ -36,6 +37,7 @@ _describe('win32', () => {
 
   test('quotePowerShell works', async () => {
     await within(async () => {
+      $.prefix = ''
       $.shell = which.sync('powershell.exe')
       $.quote = quotePowerShell
       const p = await $`echo ${`Windows 'rulez!'`}`


### PR DESCRIPTION
Closes #600 

* Mostly separates `zx/core` as mentioned in #589 
* Provides $ init / preset API

```ts
    const $$ = $({ nothrow: true, quiet: true })
    await $$`exit 1`
```

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
- [x] Types updated
