### PR TITLE
feat: add `ProcessPromise.valueOf()`

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -448,6 +448,10 @@ export class ProcessOutput extends Error {
     return this._combined
   }
 
+  valueOf() {
+    return this._combined.trim()
+  }
+
   get stdout() {
     return this._stdout
   }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -188,6 +188,17 @@ describe('core', () => {
     assert.ok(p5 !== p1)
   })
 
+  test('ProcessPromise: implements toString()', async () => {
+    const p = $`echo foo`
+    assert.equal((await p).toString(), 'foo\n')
+  })
+
+  test('ProcessPromise: implements valueOf()', async () => {
+    const p = $`echo foo`
+    assert.equal((await p).valueOf(), 'foo')
+    assert.ok((await p) == 'foo')
+  })
+
   test('cd() works with relative paths', async () => {
     let cwd = process.cwd()
     try {


### PR DESCRIPTION
closes #690

```ts
test('ProcessPromise: implements toString()', async () => {
  const p = $`echo foo`
  assert.equal((await p).toString(), 'foo\n')
})

test('ProcessPromise: implements valueOf()', async () => {
  const p = $`echo foo`
  assert.equal((await p).valueOf(), 'foo')
  assert.ok((await p) == 'foo')
})
```
