### PR TITLE
refactor: use depseek for deps extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@webpod/ps": "^0.0.0-beta.2",
         "c8": "^9.1.0",
         "chalk": "^5.3.0",
+        "depseek": "^0.4.1",
         "dts-bundle-generator": "^9.3.1",
         "esbuild": "^0.20.2",
         "esbuild-node-externals": "^1.13.0",
@@ -2007,9 +2008,9 @@
       }
     },
     "node_modules/depseek": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/depseek/-/depseek-0.4.0.tgz",
-      "integrity": "sha512-TknBvSGRZUP9TfNn7Kny8J1mb3J8T79/c1rIXRom6dpW8cEq4v81P6TJn9TJ49NwhZm97HLAAISHNP2ET2KaBg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/depseek/-/depseek-0.4.1.tgz",
+      "integrity": "sha512-YYfPPajzH9s2qnEva411VJzCMWtArBTfluI9USiKQ+T6xBWFh3C7yPxhaa1KVgJa17v9aRKc+LcRhgxS5/9mOA==",
       "dev": true
     },
     "node_modules/detective-amd": {
@@ -2327,6 +2328,12 @@
       "peerDependencies": {
         "esbuild": ">=0.19.0"
       }
+    },
+    "node_modules/esbuild-plugin-entry-chunks/node_modules/depseek": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/depseek/-/depseek-0.4.0.tgz",
+      "integrity": "sha512-TknBvSGRZUP9TfNn7Kny8J1mb3J8T79/c1rIXRom6dpW8cEq4v81P6TJn9TJ49NwhZm97HLAAISHNP2ET2KaBg==",
+      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@webpod/ps": "^0.0.0-beta.2",
     "c8": "^9.1.0",
     "chalk": "^5.3.0",
+    "depseek": "^0.4.1",
     "dts-bundle-generator": "^9.3.1",
     "esbuild": "^0.20.2",
     "esbuild-node-externals": "^1.13.0",

--- a/scripts/build-dts.mjs
+++ b/scripts/build-dts.mjs
@@ -37,7 +37,7 @@ const entry = {
       '@types/which',
       'zurk',
       '@webpod/ps',
-      'depseek'
+      'depseek',
     ], // args['external-inlines'],
   },
   output: {

--- a/scripts/build-dts.mjs
+++ b/scripts/build-dts.mjs
@@ -37,6 +37,7 @@ const entry = {
       '@types/which',
       'zurk',
       '@webpod/ps',
+      'depseek'
     ], // args['external-inlines'],
   },
   output: {

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -92,20 +92,22 @@ const builtins = new Set([
 
 const nameRe =
   /^(?<name>(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*)\/?.*$/i
-const versionRe =
-  /^@(?<version>[~^]?(v?[\dx*]+([-.][\d*a-z-]+)*))/i
+const versionRe = /^@(?<version>[~^]?(v?[\dx*]+([-.][\d*a-z-]+)*))/i
 
 export function parseDeps(content: Buffer): Record<string, string> {
-  return depseek(content.toString() + '\n', {comments: true})
-    .reduce<Record<string, string>>((m, {type, value}, i, list) => {
-      if (type === 'dep') {
-        const meta = list[i + 1]
-        const name = parsePackageName(value)
-        const version = meta?.type === 'comment' && parseVersion(meta?.value.trim()) || 'latest'
-        if (name) m[name] = version
-      }
-      return m
-    }, {})
+  return depseek(content.toString() + '\n', { comments: true }).reduce<
+    Record<string, string>
+  >((m, { type, value }, i, list) => {
+    if (type === 'dep') {
+      const meta = list[i + 1]
+      const name = parsePackageName(value)
+      const version =
+        (meta?.type === 'comment' && parseVersion(meta?.value.trim())) ||
+        'latest'
+      if (name) m[name] = version
+    }
+    return m
+  }, {})
 }
 
 function parsePackageName(path?: string): string | undefined {

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import { $ } from './core.js'
-import { spinner } from './experimental.js'
+import { spinner } from './goods.js'
+import { depseek } from './vendor.js'
 
 export async function installDeps(
   dependencies: Record<string, string>,
@@ -88,39 +89,23 @@ const builtins = new Set([
   'worker_threads',
   'zlib',
 ])
-const importRe = [
-  /\bimport\s+['"](?<path>[^'"]+)['"]/,
-  /\bimport\(['"](?<path>[^'"]+)['"]\)/,
-  /\brequire\(['"](?<path>[^'"]+)['"]\)/,
-  /\bfrom\s+['"](?<path>[^'"]+)['"]/,
-]
+
 const nameRe =
   /^(?<name>(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*)\/?.*$/i
 const versionRe =
-  /(\/\/|\/\*)\s*@(?<version>[~^]?(v?[\dx*]+([-.][\d*a-z-]+)*))/i
+  /^@(?<version>[~^]?(v?[\dx*]+([-.][\d*a-z-]+)*))/i
 
 export function parseDeps(content: Buffer): Record<string, string> {
-  const deps: Record<string, string> = {}
-  const lines = content.toString().split('\n')
-  for (let line of lines) {
-    const tuple = parseImports(line)
-    if (tuple) {
-      deps[tuple.name] = tuple.version
-    }
-  }
-  return deps
-}
-
-function parseImports(
-  line: string
-): { name: string; version: string } | undefined {
-  for (let re of importRe) {
-    const name = parsePackageName(re.exec(line)?.groups?.path)
-    const version = parseVersion(line)
-    if (name) {
-      return { name, version }
-    }
-  }
+  return depseek(content.toString() + '\n', {comments: true})
+    .reduce<Record<string, string>>((m, {type, value}, i, list) => {
+      if (type === 'dep') {
+        const meta = list[i + 1]
+        const name = parsePackageName(value)
+        const version = meta?.type === 'comment' && parseVersion(meta?.value.trim()) || 'latest'
+        if (name) m[name] = version
+      }
+      return m
+    }, {})
 }
 
 function parsePackageName(path?: string): string | undefined {

--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -50,6 +50,7 @@ export const YAML: {
 
 export const fs: typeof import('fs-extra') = _fs
 
+export { depseekSync as depseek } from 'depseek'
 export { type Options as GlobbyOptions } from 'globby'
 export { default as chalk, type ChalkInstance } from 'chalk'
 export { default as which } from 'which'

--- a/test/deps.test.js
+++ b/test/deps.test.js
@@ -95,6 +95,8 @@ describe('deps', () => {
   import fs from 'fs'
   import path from 'path'
   import foo from "foo"
+  // import aaa from 'a'
+  /* import bbb from 'b' */ 
   import bar from "bar" /* @1.0.0 */
   import baz from "baz" //    @^2.0
   import qux from "@qux/pkg/entry" //    @^3.0

--- a/test/fixtures/js-project/package-lock.json
+++ b/test/fixtures/js-project/package-lock.json
@@ -23,6 +23,7 @@
         "@webpod/ps": "^0.0.0-beta.2",
         "c8": "^9.1.0",
         "chalk": "^5.3.0",
+        "depseek": "^0.4.1",
         "dts-bundle-generator": "^9.3.1",
         "esbuild": "^0.20.2",
         "esbuild-node-externals": "^1.13.0",


### PR DESCRIPTION
```ts
// This should be captured
import 'foo' // @1.2.3

// But the rest should be ignored
// import bar from 'bar'
/* import baz from 'baz' */
```

* [x] Tested
