### PR TITLE
feat: let `cwdHook` be configurable

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -191,7 +191,7 @@ export const $: Shell & Options = new Proxy<Shell & Options>(
     },
   }
 )
-$.cwdHook = true
+$.cwdHook = false
 try {
   setupBash()
 } catch (err) {}

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -41,7 +41,8 @@ declare global {
   var quote: typeof _.quote
   var quotePowerShell: typeof _.quotePowerShell
   var retry: typeof _.retry
-  var setupPowerShell: typeof _.setupPowerShell
+  var usePowerShell: typeof _.usePowerShell
+  var useBash: typeof _.useBash
   var sleep: typeof _.sleep
   var spinner: typeof _.spinner
   var stdin: typeof _.stdin

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,6 +42,10 @@ export function normalizeMultilinePieces(
   )
 }
 
+export function noquote(): string {
+  throw new Error('No quote function is defined: https://ï.at/no-quote-func')
+}
+
 export function quote(arg: string) {
   if (/^[a-z0-9/_.\-@:=]+$/i.test(arg) || arg === '') {
     return arg

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -263,25 +263,25 @@ describe('core', () => {
     }
   })
 
-  test('cd() does affect parallel contexts', async () => {
+  test('cd() does not affect parallel contexts', async () => {
     const cwd = process.cwd()
     try {
       fs.mkdirpSync('/tmp/zx-cd-parallel/one/two')
       await Promise.all([
         within(async () => {
           assert.equal(process.cwd(), cwd)
-          await sleep(1)
           cd('/tmp/zx-cd-parallel/one')
+          await sleep(Math.random() * 15)
           assert.ok(process.cwd().endsWith('/tmp/zx-cd-parallel/one'))
         }),
         within(async () => {
           assert.equal(process.cwd(), cwd)
-          await sleep(2)
+          await sleep(Math.random() * 15)
           assert.equal(process.cwd(), cwd)
         }),
         within(async () => {
           assert.equal(process.cwd(), cwd)
-          await sleep(3)
+          await sleep(Math.random() * 15)
           $.cwd = '/tmp/zx-cd-parallel/one/two'
           assert.equal(process.cwd(), cwd)
           assert.ok(

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -232,14 +232,6 @@ describe('core', () => {
     assert.ok((await p) == 'foo')
   })
 
-  test('$.cwdHook is configurable', () => {
-    $.cwdHook = true
-    assert.equal($.cwdHook, true)
-
-    $.cwdHook = false
-    assert.equal($.cwdHook, false)
-  })
-
   test('cd() works with relative paths', async () => {
     let cwd = process.cwd()
     try {
@@ -271,8 +263,8 @@ describe('core', () => {
     }
   })
 
-  test('cd() does not affect parallel contexts ($.cwdHook enabled)', async () => {
-    $.cwdHook = true
+  test('cd() does not affect parallel contexts ($.cwdSyncHook enabled)', async () => {
+    syncProcessCwd()
     const cwd = process.cwd()
     try {
       fs.mkdirpSync('/tmp/zx-cd-parallel/one/two')
@@ -306,7 +298,7 @@ describe('core', () => {
     } finally {
       fs.rmSync('/tmp/zx-cd-parallel', { recursive: true })
       cd(cwd)
-      $.cwdHook = false
+      syncProcessCwd(false)
     }
   })
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -232,6 +232,13 @@ describe('core', () => {
     assert.ok((await p) == 'foo')
   })
 
+  test('$.cwdHook is configurable', () => {
+    $.cwdHook = false
+    assert.equal($.cwdHook, false)
+    $.cwdHook = true
+    assert.equal($.cwdHook, true)
+  })
+
   test('cd() works with relative paths', async () => {
     let cwd = process.cwd()
     try {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -233,10 +233,11 @@ describe('core', () => {
   })
 
   test('$.cwdHook is configurable', () => {
-    $.cwdHook = false
-    assert.equal($.cwdHook, false)
     $.cwdHook = true
     assert.equal($.cwdHook, true)
+
+    $.cwdHook = false
+    assert.equal($.cwdHook, false)
   })
 
   test('cd() works with relative paths', async () => {
@@ -270,7 +271,8 @@ describe('core', () => {
     }
   })
 
-  test('cd() does not affect parallel contexts', async () => {
+  test('cd() does not affect parallel contexts ($.cwdHook enabled)', async () => {
+    $.cwdHook = true
     const cwd = process.cwd()
     try {
       fs.mkdirpSync('/tmp/zx-cd-parallel/one/two')
@@ -304,6 +306,7 @@ describe('core', () => {
     } finally {
       fs.rmSync('/tmp/zx-cd-parallel', { recursive: true })
       cd(cwd)
+      $.cwdHook = false
     }
   })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,6 +20,9 @@ import {
   $,
   log,
   cd,
+  syncProcessCwd,
+  usePowerShell,
+  useBash,
   kill,
   ProcessOutput,
   ProcessPromise,
@@ -60,10 +63,13 @@ describe('index', () => {
     assert(ProcessOutput)
     assert(ProcessPromise)
     assert(cd)
+    assert(syncProcessCwd)
     assert(log)
     assert(kill)
     assert(defaults)
     assert(within)
+    assert(usePowerShell)
+    assert(useBash)
 
     // goods
     assert(argv)

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -17,8 +17,8 @@ import { test, describe, beforeEach, before, after } from 'node:test'
 import '../build/globals.js'
 
 describe('package', () => {
-  before(() => $.cwdHook = true)
-  after(() => $.cwdHook = false)
+  before(() => syncProcessCwd())
+  after(() => syncProcessCwd(false))
   beforeEach(async () => {
     const pack = await $`npm pack`
     await $`tar xf ${pack}`

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 import assert from 'node:assert'
-import { test, describe, beforeEach } from 'node:test'
+import { test, describe, beforeEach, before, after } from 'node:test'
 import '../build/globals.js'
 
 describe('package', () => {
+  before(() => $.cwdHook = true)
+  after(() => $.cwdHook = false)
   beforeEach(async () => {
     const pack = await $`npm pack`
     await $`tar xf ${pack}`

--- a/test/smoke/win32.test.js
+++ b/test/smoke/win32.test.js
@@ -24,7 +24,7 @@ _describe('win32', () => {
     assert.match(p.stdout, /bash/)
 
     await within(async () => {
-      setupPowerShell()
+      usePowerShell()
       assert.match($.shell, /powershell/i)
       const p = await $`get-host`
       assert.match(p.stdout, /PowerShell/)
@@ -33,7 +33,7 @@ _describe('win32', () => {
 
   test('quotePowerShell works', async () => {
     await within(async () => {
-      setupPowerShell()
+      usePowerShell()
       const p = await $`echo ${`Windows 'rulez!'`}`
       assert.match(p.stdout, /Windows 'rulez!'/)
     })


### PR DESCRIPTION
```ts
process.cwd() // foo
$.cwdHook = false

within(async() => {
   cd('/bar')
   await sleep(10)
   await $`pwd` // now it is `/qux`, not `/bar`
})

cd('/qux')
```
