### PR TITLE
fix: allow spaces in commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 await $`cat package.json | grep name`
 
-let branch = await $`git branch --show-current`
+let { stdout: branch } = await $`git branch --show-current`
 await $`dep deploy --branch=${branch}`
 
 await Promise.all([

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zx",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zx",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "Apache-2.0",
       "bin": {
         "zx": "build/cli.js"

--- a/src/util.ts
+++ b/src/util.ts
@@ -48,7 +48,7 @@ export function noquote(): string {
 }
 
 export function quote(arg: string) {
-  if (/^[a-z0-9/_.\-@:=]+$/i.test(arg) || arg === '') {
+  if (/^[a-z0-9/_.\-@:= ]+$/i.test(arg) || arg === '') {
     return arg
   }
   return (

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -44,6 +44,12 @@ describe('core', () => {
     assert.equal((await $`echo ${bar}`).stdout.trim(), bar)
   })
 
+  test('arguments can have spaces and will be quoted', async () => {
+    const message = 'hello: John Smith';
+    const cmd = `echo ${message}`
+    assert.equal((await $`${cmd}`).stdout.trim(), message);
+  })
+
   test('undefined and empty string correctly quoted', async () => {
     assert.equal((await $`echo -n ${undefined}`).toString(), 'undefined')
     assert.equal((await $`echo -n ${''}`).toString(), '')

--- a/test/fixtures/js-project/package-lock.json
+++ b/test/fixtures/js-project/package-lock.json
@@ -9,7 +9,7 @@
       }
     },
     "../../..": {
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "Apache-2.0",
       "bin": {
         "zx": "build/cli.js"

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -57,6 +57,7 @@ describe('util', () => {
 
   test('quote()', () => {
     assert.ok(quote('string') === 'string')
+    assert.ok(quote('this that') === 'this that')
     assert.ok(quote(`'\f\n\r\t\v\0`) === `$'\\'\\f\\n\\r\\t\\v\\0'`)
   })
 


### PR DESCRIPTION
Fixes #700 

Allows for spaces to exist in commands.

```js
const cmd = `echo hello: ${process.env.NAME}`
await $`${cmd}`
```

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
- [ ] Types updated
