### PR TITLE
#787 support CRLF for markdown script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/fixtures/markdown-crlf.md eol=crlf

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -195,7 +195,7 @@ function transformMarkdown(buf: Buffer) {
   const jsCodeBlock = /^(```+|~~~+)(js|javascript)$/
   const shCodeBlock = /^(```+|~~~+)(sh|bash)$/
   const otherCodeBlock = /^(```+|~~~+)(.*)$/
-  for (let line of source.split('\n')) {
+  for (let line of source.split(/\r?\n/)) {
     switch (state) {
       case 'root':
         if (/^( {4}|\t)/.test(line) && prevLineIsEmpty) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -142,6 +142,11 @@ describe('cli', () => {
     await $`node build/cli.js test/fixtures/markdown.md`
   })
 
+  test('markdown scripts are working for CRLF', async () => {
+    let p = await $`node build/cli.js test/fixtures/markdown-crlf.md`
+    assert.ok(p.stdout.includes('Hello, world!'))
+  })
+
   test('exceptions are caught', async () => {
     let out1 = await $`node build/cli.js <<<${'await $`wtf`'}`.nothrow()
     assert.match(out1.stderr, /Error:/)

--- a/test/fixtures/markdown-crlf.md
+++ b/test/fixtures/markdown-crlf.md
@@ -1,0 +1,3 @@
+```js
+echo`Hello, world!`
+```


### PR DESCRIPTION
Fixes #787

support Windows CRLF line ending when split lines in transformMarkdown.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
- [x] Types updated
