### PR TITLE
feat: add `usePwsh` helper for PowerShell v7+

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -117,6 +117,13 @@ export function usePowerShell() {
   $.quote = quotePowerShell
 }
 
+export function usePwsh() {
+  $.shell = which.sync('pwsh')
+  $.prefix = ''
+  $.postfix = '; exit $LastExitCode'
+  $.quote = quotePowerShell
+}
+
 export function useBash() {
   $.shell = which.sync('bash')
   $.prefix = 'set -euo pipefail;'

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -42,6 +42,7 @@ declare global {
   var quotePowerShell: typeof _.quotePowerShell
   var retry: typeof _.retry
   var usePowerShell: typeof _.usePowerShell
+  var usePwsh: typeof _.usePwsh
   var useBash: typeof _.useBash
   var sleep: typeof _.sleep
   var spinner: typeof _.spinner

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -586,7 +586,7 @@ describe('core', () => {
 
   test('usePwsh() sets proper defaults', () => {
     const originalWhichSync = which.sync
-    which.sync = bin => bin === 'pwsh' ? 'pwsh' : originalWhichSync(bin)
+    which.sync = (bin) => (bin === 'pwsh' ? 'pwsh' : originalWhichSync(bin))
     usePwsh()
     assert.equal($.shell, 'pwsh')
     assert.equal($.prefix, '')

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -18,7 +18,7 @@ import { inspect } from 'node:util'
 import { basename } from 'node:path'
 import { Readable, Writable } from 'node:stream'
 import { Socket } from 'node:net'
-import { ProcessPromise, ProcessOutput } from '../build/index.js'
+import { ProcessPromise, ProcessOutput, quotePowerShell } from '../build/index.js'
 import '../build/globals.js'
 
 describe('core', () => {
@@ -582,5 +582,16 @@ describe('core', () => {
       assert.equal(err.message, 'The process is halted!')
     }
     assert.ok(ok, 'Expected failure!')
+  })
+
+  test('usePwsh() sets proper defaults', () => {
+    const originalWhichSync = which.sync
+    which.sync = bin => bin === 'pwsh' ? 'pwsh' : originalWhichSync(bin)
+    usePwsh()
+    assert.equal($.shell, 'pwsh')
+    assert.equal($.prefix, '')
+    assert.equal($.postfix, '; exit $LastExitCode')
+    assert.equal($.quote, quotePowerShell)
+    which.sync = originalWhichSync
   })
 })

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -18,7 +18,7 @@ import { inspect } from 'node:util'
 import { basename } from 'node:path'
 import { Readable, Writable } from 'node:stream'
 import { Socket } from 'node:net'
-import { ProcessPromise, ProcessOutput, quotePowerShell } from '../build/index.js'
+import { ProcessPromise, ProcessOutput } from '../build/index.js'
 import '../build/globals.js'
 
 describe('core', () => {
@@ -593,5 +593,6 @@ describe('core', () => {
     assert.equal($.postfix, '; exit $LastExitCode')
     assert.equal($.quote, quotePowerShell)
     which.sync = originalWhichSync
+    useBash()
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,6 +22,7 @@ import {
   cd,
   syncProcessCwd,
   usePowerShell,
+  usePwsh,
   useBash,
   kill,
   ProcessOutput,
@@ -69,6 +70,7 @@ describe('index', () => {
     assert(defaults)
     assert(within)
     assert(usePowerShell)
+    assert(usePwsh)
     assert(useBash)
 
     // goods

--- a/test/smoke/win32.test.js
+++ b/test/smoke/win32.test.js
@@ -15,7 +15,6 @@
 import assert from 'node:assert'
 import { test, describe } from 'node:test'
 import '../../build/globals.js'
-import { which } from '../../build/vendor.js'
 
 const _describe = process.platform === 'win32' ? describe : describe.skip
 

--- a/test/smoke/win32.test.js
+++ b/test/smoke/win32.test.js
@@ -14,9 +14,12 @@
 
 import assert from 'node:assert'
 import { test, describe } from 'node:test'
+import which from 'which'
 import '../../build/globals.js'
 
 const _describe = process.platform === 'win32' ? describe : describe.skip
+
+const _testPwsh = which.sync('pwsh', { nothrow: true }) ? test : test.skip
 
 _describe('win32', () => {
   test('should work with windows-specific commands', async () => {
@@ -36,6 +39,15 @@ _describe('win32', () => {
       usePowerShell()
       const p = await $`echo ${`Windows 'rulez!'`}`
       assert.match(p.stdout, /Windows 'rulez!'/)
+    })
+  })
+
+  _testPwsh('should work with pwsh when it is available', async () => {
+    await within(async () => {
+      usePwsh()
+      assert.match($.shell, /pwsh/i)
+      const p = await $`echo 'Hello,' && echo ${`new 'PowerShell'!`}`
+      assert.match(p.stdout, /Hello,\s+new 'PowerShell'!/)
     })
   })
 })

--- a/test/smoke/win32.test.js
+++ b/test/smoke/win32.test.js
@@ -14,8 +14,8 @@
 
 import assert from 'node:assert'
 import { test, describe } from 'node:test'
-import which from 'which'
 import '../../build/globals.js'
+import { which } from '../../build/vendor.js'
 
 const _describe = process.platform === 'win32' ? describe : describe.skip
 


### PR DESCRIPTION
Fixes https://github.com/google/zx/issues/785

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
- [x] Types updated

## Notes

No documentation was added. I haven't found any documentation for other helpers apart from release notes...

A smoke test was added to `win32` test but I'm not sure if it's a good idea.
- `pwsh` is not available by default
- `pwsh` can be used on any supported platform

So the last commit can be dropped. Or I can create a new smoke test.

## Description

A new helper `usePwsh` to use `pwsh` shell (PowerShell v7+).

```js
import { usePowerShell, usePwsh } from 'zx'

usePowerShell() // to enable powershell.exe (PowerShell v5 on Windows)
usePwsh()       // switch to pwsh (PowerShell v7 on any supported platform)
```

## Usage

Tested on Windows 11 and Fedora 38

<table>

<tr><td>

```js
usePwsh()
console.log((await $`echo 'Foo' && echo 'Bar'`).stdout)
```

</td><td>

```
Foo
Bar
```

</td>

</tr><tr><td>

```js
usePowerShell()
console.log((await $`echo 'Foo' && echo 'Bar'`).stdout)
```

</td><td>

```
At line:1 char:12
+ echo 'Foo' && echo 'Bar'; exit $LastExitCode
+            ~~
The token '&&' is not a valid statement separator in this version.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : InvalidEndOfLine
```

</td></tr>