### PR TITLE
feat: let timeout be configurable via $ opts

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -59,6 +59,8 @@ export interface Options {
   ac?: AbortController
   signal?: AbortSignal
   input?: string | Buffer | Readable | ProcessOutput | ProcessPromise
+  timeout?: Duration
+  timeoutSignal?: string
   stdio: StdioOptions
   verbose: boolean
   sync: boolean
@@ -246,6 +248,7 @@ export class ProcessPromise extends Promise<ProcessOutput> {
     const input = ($.input as ProcessPromise | ProcessOutput)?.stdout ?? $.input
 
     if (input) this.stdio('pipe')
+    if ($.timeout) this.timeout($.timeout, $.timeoutSignal)
 
     $.log({
       kind: 'cmd',

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -480,6 +480,21 @@ describe('core', () => {
     assert.equal(signal, 'SIGKILL')
   })
 
+  test('timeout is configurable via opts', async () => {
+    let exitCode, signal
+    try {
+      await $({
+        timeout: 10,
+        timeoutSignal: 'SIGKILL',
+      })`sleep 999`
+    } catch (p) {
+      exitCode = p.exitCode
+      signal = p.signal
+    }
+    assert.equal(exitCode, null)
+    assert.equal(signal, 'SIGKILL')
+  })
+
   test('timeout() expiration works', async () => {
     let exitCode, signal
     try {


### PR DESCRIPTION
```ts
const p = $({timeout: '1s'})`sleep 99`
```

- [x] Tests pass
