### PR TITLE
feat: add ProcessPromise `.verbose()` for symmetry with`.quiet()`

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -220,6 +220,7 @@ export class ProcessPromise extends Promise<ProcessOutput> {
   private _stdio?: StdioOptions
   private _nothrow?: boolean
   private _quiet?: boolean
+  private _verbose?: boolean
   private _timeout?: number
   private _timeoutSignal = 'SIGTERM'
   private _resolved = false
@@ -487,8 +488,13 @@ export class ProcessPromise extends Promise<ProcessOutput> {
     return this
   }
 
-  quiet(): ProcessPromise {
-    this._quiet = true
+  quiet(v = true): ProcessPromise {
+    this._quiet = v
+    return this
+  }
+
+  verbose(v = true): ProcessPromise {
+    this._verbose = v
     return this
   }
 
@@ -497,7 +503,7 @@ export class ProcessPromise extends Promise<ProcessOutput> {
   }
 
   isVerbose(): boolean {
-    return this._snapshot.verbose && !this.isQuiet()
+    return (this._verbose ?? this._snapshot.verbose) && !this.isQuiet()
   }
 
   timeout(d: Duration, signal = 'SIGTERM'): ProcessPromise {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -458,6 +458,17 @@ describe('core', () => {
       }
     })
 
+    test('verbose() mode is working', async () => {
+      const p = $`echo 'test'`
+      assert.equal(p.isVerbose(), false)
+
+      p.verbose()
+      assert.equal(p.isVerbose(), true)
+
+      p.verbose(false)
+      assert.equal(p.isVerbose(), false)
+    })
+
     test('nothrow() do not throw', async () => {
       let { exitCode } = await $`exit 42`.nothrow()
       assert.equal(exitCode, 42)


### PR DESCRIPTION
relates #710

<!-- Usage demo -->
```js
const p = $`echo foo`
p.quiet()        // enable silent mode
p.quiet(false)   // then disable
p.verbose()      // enable verbose/debug mode
p.verbose(false) // and turn it off

await p
```

- [x] Tests pass
