### PR TITLE
fix(cli): return exit code 1 on incorrect inputs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,12 +49,23 @@ function printUsage() {
    --version, -v        print current zx version
    --help, -h           print help
    --repl               start repl
+   --experimental       enables experimental features (deprecated)
+ 
+ ${chalk.italic('Full documentation:')} ${chalk.underline('https://google.github.io/zx/')}
 `)
 }
 
 const argv = minimist(process.argv.slice(2), {
   string: ['shell', 'prefix', 'postfix', 'eval', 'cwd'],
-  boolean: ['version', 'help', 'quiet', 'verbose', 'install', 'repl'],
+  boolean: [
+    'version',
+    'help',
+    'quiet',
+    'verbose',
+    'install',
+    'repl',
+    'experimental',
+  ],
   alias: { e: 'eval', i: 'install', v: 'version', h: 'help' },
   stopEarly: true,
 })
@@ -87,7 +98,10 @@ const argv = minimist(process.argv.slice(2), {
   updateArgv(argv._.slice(firstArg === undefined ? 0 : 1))
   if (!firstArg || firstArg === '-') {
     const success = await scriptFromStdin()
-    if (!success) printUsage()
+    if (!success) {
+      printUsage()
+      process.exitCode = 1
+    }
     return
   }
   if (/^https?:/.test(firstArg)) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -49,8 +49,13 @@ describe('cli', () => {
   test('zx prints usage if no param passed', async () => {
     let p = $`node build/cli.js`
     p.stdin.end()
-    let out = await p
-    assert.match(out.stdout, /A tool for writing better scripts/)
+    try {
+      await p
+      assert.fail('must throw')
+    } catch (out) {
+      assert.match(out.stdout, /A tool for writing better scripts/)
+      assert.equal(out.exitCode, 1)
+    }
   })
 
   test('starts repl with --repl', async () => {


### PR DESCRIPTION
Set exit code 1 on incorrect (empty) parametrization.

```bash
zx --foo || echo test
```
↓
```
zx 8.1.1
   A tool for writing better scripts
...
test
```


