### PR TITLE
fix: disable redundant node-fetch-native runtime check (deno)

### DIFF
--- a/scripts/build-js.mjs
+++ b/scripts/build-js.mjs
@@ -126,6 +126,7 @@ plugins.push(
             )
             .replaceAll('require("fs/promises")', 'require("fs").promises')
             .replaceAll('}).prototype', '}).prototype || {}')
+            .replace(/DISABLE_NODE_FETCH_NATIVE_WARN/, ($0) => `${$0} || true`)
             .replace(
               /\/\/ Annotate the CommonJS export names for ESM import in node:/,
               ($0) => `/* c8 ignore next 100 */\n${$0}`


### PR DESCRIPTION
https://github.com/unjs/node-fetch-native/blob/main/src/node.ts#L24
https://github.com/unjs/node-fetch-native/pull/128

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
