### PR TITLE
docs: mention CLI `verbose flag

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,8 @@ export function printUsage() {
    zx [options] <script>
 
  ${chalk.bold('Options')}
-   --quiet              don't echo commands
+   --quiet              suppress any outputs
+   --verbose            enable verbose mode
    --shell=<path>       custom shell binary
    --prefix=<command>   prefix all commands
    --postfix=<command>  postfix all commands


### PR DESCRIPTION
```js
 ${chalk.bold('Options')}
   --quiet              suppress any outputs
   --verbose            enable verbose mode
```
