### PR TITLE
fix(global): add missing types

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -26,6 +26,7 @@ declare global {
   var argv: typeof _.argv
   var cd: typeof _.cd
   var chalk: typeof _.chalk
+  var defaults: typeof _.defaults
   var echo: typeof _.echo
   var expBackoff: typeof _.expBackoff
   var fs: typeof _.fs


### PR DESCRIPTION
In my company's repo, we needed to change the defaults object to set the global configuration (I don't know why but I had to), and I found that when I use `import "zx/globals"`, it will mount `defaults` obj to globalThis, but there is no type definition in mjs file, so I want to fix it.
```js
var defaults: typeof _.defaults
```

- [x] Tests pass
