### PR TITLE
fix: omit redundant yaml API extras

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -9,7 +9,7 @@
   {
     "name": "zx/index",
     "path": "build/*.{js,cjs}",
-    "limit": "842 kB",
+    "limit": "781 kB",
     "brotli": false,
     "gzip": false
   },
@@ -23,14 +23,14 @@
   {
     "name": "vendor",
     "path": "build/vendor-*",
-    "limit": "803 kB",
+    "limit": "745 kB",
     "brotli": false,
     "gzip": false
   },
   {
     "name": "all",
     "path": "build/*",
-    "limit": "875 kB",
+    "limit": "815 kB",
     "brotli": false,
     "gzip": false
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zx",
-  "version": "8.1.3",
+  "version": "8.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zx",
-      "version": "8.1.3",
+      "version": "8.1.4",
       "license": "Apache-2.0",
       "bin": {
         "zx": "build/cli.js"
@@ -29,6 +29,7 @@
         "esbuild-plugin-entry-chunks": "^0.1.15",
         "esbuild-plugin-extract-helpers": "^0.0.6",
         "esbuild-plugin-hybrid-export": "^0.2.4",
+        "esbuild-plugin-resolve": "^2.0.0",
         "esbuild-plugin-transform-hook": "^0.1.1",
         "esbuild-plugin-utils": "^0.1.0",
         "fs-extra": "^11.2.0",
@@ -1837,6 +1838,13 @@
       "peerDependencies": {
         "esbuild": ">=0.19.0"
       }
+    },
+    "node_modules/esbuild-plugin-resolve": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-resolve/-/esbuild-plugin-resolve-2.0.0.tgz",
+      "integrity": "sha512-eJy9B8yDW5X/J48eWtR1uVmv+DKfHvYYnrrcqQoe/nUkVHVOTZlJnSevkYyGOz6hI90t036Y5QIPDrGzmppxfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild-plugin-transform-hook": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "esbuild-plugin-entry-chunks": "^0.1.15",
     "esbuild-plugin-extract-helpers": "^0.0.6",
     "esbuild-plugin-hybrid-export": "^0.2.4",
+    "esbuild-plugin-resolve": "^2.0.0",
     "esbuild-plugin-transform-hook": "^0.1.1",
     "esbuild-plugin-utils": "^0.1.0",
     "fs-extra": "^11.2.0",

--- a/scripts/build-js.mjs
+++ b/scripts/build-js.mjs
@@ -23,8 +23,11 @@ import { entryChunksPlugin } from 'esbuild-plugin-entry-chunks'
 import { hybridExportPlugin } from 'esbuild-plugin-hybrid-export'
 import { transformHookPlugin } from 'esbuild-plugin-transform-hook'
 import { extractHelpersPlugin } from 'esbuild-plugin-extract-helpers'
+import esbuildResolvePlugin from 'esbuild-plugin-resolve'
 import minimist from 'minimist'
 import glob from 'fast-glob'
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname)
 
 const argv = minimist(process.argv.slice(2), {
   default: {
@@ -54,7 +57,6 @@ const {
 } = argv
 
 const formats = format.split(',')
-const plugins = []
 const cwd = Array.isArray(_cwd) ? _cwd[_cwd.length - 1] : _cwd
 const entries = entry.split(/:\s?/)
 const entryPoints = entry.includes('*')
@@ -63,6 +65,12 @@ const entryPoints = entry.includes('*')
 
 const _bundle = bundle !== 'none' && !process.argv.includes('--no-bundle')
 const _external = _bundle ? external.split(',') : undefined // https://github.com/evanw/esbuild/issues/1466
+
+const plugins = [
+  esbuildResolvePlugin({
+    yaml: path.resolve(__dirname, '../node_modules/yaml/browser'),
+  }),
+]
 
 if (_bundle && entryPoints.length > 1) {
   plugins.push(entryChunksPlugin())

--- a/src/vendor-extra.ts
+++ b/src/vendor-extra.ts
@@ -25,10 +25,10 @@ import {
   isDynamicPattern,
   type Options as GlobbyOptions,
 } from 'globby'
-import * as yaml from 'yaml'
+import { parse as yamlParse, stringify as yamlStringify } from 'yaml'
 import * as _fs from 'fs-extra'
 import _createRequire from 'create-require'
-import { type fetch, AbortController } from 'node-fetch-native'
+import { AbortController } from 'node-fetch-native'
 
 export { fetch as nodeFetch } from 'node-fetch-native'
 
@@ -60,7 +60,10 @@ export const glob = Object.assign(function globby(
 export const YAML: {
   parse(text: string): any
   stringify(object: any): string
-} = yaml
+} = {
+  parse: yamlParse,
+  stringify: yamlStringify,
+}
 
 export const fs: typeof import('fs-extra') = _fs
 

--- a/test/vendor.test.js
+++ b/test/vendor.test.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import './cli.test.js'
-import './core.test.js'
-import './deps.test.js'
-import './global.test.js'
-import './goods.test.js'
-import './index.test.js'
-import './package.test.js'
-import './util.test.js'
-import './vendor.test.js'
+import assert from 'node:assert'
+import { test, describe } from 'node:test'
+import { YAML } from '../build/vendor.js'
+
+describe('YAML', () => {
+  test('YAML.parse', () => {
+    assert.deepEqual(YAML.parse('a: b\n'), { a: 'b' })
+  })
+
+  test('YAML.stringify', () => {
+    assert.equal(YAML.stringify({ a: 'b' }), 'a: b\n')
+  })
+})


### PR DESCRIPTION
* Remove redundant (undocumented) YAML API extras
* Override yaml pkg entry point from cjs to esm: reduce vendor bundle size by ~65Kb

Fixes #863 

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
