### PR TITLE
test(core): enhance cwd related test for `within`

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -41,11 +41,12 @@ import {
   exitCodeInfo,
   formatCmd,
   getCallerLocation,
+  isString,
   noop,
   parseDuration,
+  preferNmBin,
   quote,
   quotePowerShell,
-  preferNmBin,
 } from './util.js'
 
 export interface Shell {
@@ -445,7 +446,7 @@ export class ProcessPromise extends Promise<ProcessOutput> {
   }
 
   pipe(dest: Writable | ProcessPromise): ProcessPromise {
-    if (typeof dest === 'string')
+    if (isString(dest))
       throw new Error('The pipe() method does not take strings. Forgot $?')
     if (this._resolved) {
       if (dest instanceof ProcessPromise) dest.stdin.end() // In case of piped stdin, we may want to close stdin of dest as well.

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -740,17 +740,22 @@ describe('core', () => {
       await promise
     })
 
-    test('restores previous cwd', async () => {
+    test('keeps the cwd ref for internal $ calls', async () => {
       let resolve, reject
       let promise = new Promise((...args) => ([resolve, reject] = args))
-
+      let cwd = process.cwd()
       let pwd = await $`pwd`
 
       within(async () => {
         cd('/tmp')
+        assert.ok(process.cwd().endsWith('/tmp'))
+        assert.ok((await $`pwd`).stdout.trim().endsWith('/tmp'))
+
         setTimeout(async () => {
+          process.chdir('/')
           assert.ok((await $`pwd`).stdout.trim().endsWith('/tmp'))
           resolve()
+          process.chdir(cwd)
         }, 1000)
       })
 


### PR DESCRIPTION
relates #876 
