### PR TITLE
feat: let $ presets be composable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,12 +41,12 @@
         "prettier": "^3.3.3",
         "size-limit": "^11.1.4",
         "ts-node": "^10.9.2",
-        "tsd": "^0.31.1",
+        "tsd": "^0.31.2",
         "tsx": "^4.19.0",
         "typescript": "^5.5.4",
         "which": "^4.0.0",
-        "yaml": "^2.5.0",
-        "zurk": "^0.3.0"
+        "yaml": "^2.5.1",
+        "zurk": "^0.3.1"
       },
       "engines": {
         "node": ">= 12.17.0"
@@ -4817,9 +4817,9 @@
       }
     },
     "node_modules/tsd": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.31.1.tgz",
-      "integrity": "sha512-sSL84A0SFwx2xGMWrxlGaarKFSQszWjJS2vgNDDLwatytzg2aq6ShlwHsBYxRNmjzXISODwMva5ZOdAg/4AoOA==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.31.2.tgz",
+      "integrity": "sha512-VplBAQwvYrHzVihtzXiUVXu5bGcr7uH1juQZ1lmKgkuGNGT+FechUCqmx9/zk7wibcqR2xaNEwCkDyKh+VVZnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5183,9 +5183,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
-      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
+      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5248,9 +5248,9 @@
       }
     },
     "node_modules/zurk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.3.0.tgz",
-      "integrity": "sha512-/IzRO+3KASjOnFoZqvJxYUryJoqh0P9le0KjKCtyUnW1mD9E6Msj60LPprpVt50hHfvkzCR6QNlf2hI6PeIDvA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zurk/-/zurk-0.3.1.tgz",
+      "integrity": "sha512-E3c+/eH13P51YDeXIKXPZRzCXEBaKAw3ifDGCv6XxTH7Tc4feBcJaKK6J7OTHtrdn/V+HIWKdordShInX1TWxQ==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -120,12 +120,12 @@
     "prettier": "^3.3.3",
     "size-limit": "^11.1.4",
     "ts-node": "^10.9.2",
-    "tsd": "^0.31.1",
+    "tsd": "^0.31.2",
     "tsx": "^4.19.0",
     "typescript": "^5.5.4",
     "which": "^4.0.0",
-    "yaml": "^2.5.0",
-    "zurk": "^0.3.0"
+    "yaml": "^2.5.1",
+    "zurk": "^0.3.1"
   },
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"

--- a/src/core.ts
+++ b/src/core.ts
@@ -164,11 +164,12 @@ function getStore() {
 
 export const $: Shell & Options = new Proxy<Shell & Options>(
   function (pieces, ...args) {
+    const snapshot = getStore()
     if (!Array.isArray(pieces)) {
       return function (this: any, ...args: any) {
         const self = this
         return within(() => {
-          return Object.assign($, pieces).apply(self, args)
+          return Object.assign($, snapshot, pieces).apply(self, args)
         })
       }
     }
@@ -186,7 +187,6 @@ export const $: Shell & Options = new Proxy<Shell & Options>(
       pieces as TemplateStringsArray,
       args
     ) as string
-    const snapshot = getStore()
     const sync = snapshot[syncExec]
     const callback = () => promise.isHalted() || promise.run()
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -168,14 +168,19 @@ describe('core', () => {
     test('`$.sync()` provides synchronous API', () => {
       const o1 = $.sync`echo foo`
       const o2 = $({ sync: true })`echo foo`
+      const o3 = $.sync({})`echo foo`
       assert.equal(o1.stdout, 'foo\n')
       assert.equal(o2.stdout, 'foo\n')
+      assert.equal(o3.stdout, 'foo\n')
     })
 
     describe('$({opts}) API', () => {
       test('provides presets', async () => {
         const $$ = $({ nothrow: true })
         assert.equal((await $$`exit 1`).exitCode, 1)
+
+        const $$$ = $$({ sync: true })
+        assert.equal($$$`exit 2`.exitCode, 2)
       })
 
       test('handles `input` option', async () => {


### PR DESCRIPTION
Fixes #881 

```js
const $$ = $({ nothrow: true })
assert.equal((await $$`exit 1`).exitCode, 1)

const $$$ = $$({ sync: true }) // Both {nothrow: true, sync: true} are applied
assert.equal($$$`exit 2`.exitCode, 2)
```

- [x] Tests pass

