### PR TITLE
feat: enable stringLiterals for `pipe()` API

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -9,7 +9,7 @@
   {
     "name": "zx/index",
     "path": "build/*.{js,cjs}",
-    "limit": "795 kB",
+    "limit": "796 kB",
     "brotli": false,
     "gzip": false
   },

--- a/src/core.ts
+++ b/src/core.ts
@@ -30,6 +30,7 @@ import {
   chalk,
   which,
   ps,
+  isStringLiteral,
   type ChalkInstance,
   type RequestInfo,
   type RequestInit,
@@ -461,7 +462,12 @@ export class ProcessPromise extends Promise<ProcessOutput> {
     return super.catch(onrejected)
   }
 
-  pipe(dest: Writable | ProcessPromise): ProcessPromise {
+  pipe(
+    dest: Writable | ProcessPromise | TemplateStringsArray,
+    ...args: any[]
+  ): ProcessPromise {
+    if (isStringLiteral(dest))
+      return this.pipe($(dest as TemplateStringsArray, ...args))
     if (isString(dest))
       throw new Error('The pipe() method does not take strings. Forgot $?')
     if (this._resolved) {
@@ -488,7 +494,7 @@ export class ProcessPromise extends Promise<ProcessOutput> {
       }
       return dest
     } else {
-      this._postrun = () => this.stdout.pipe(dest)
+      this._postrun = () => this.stdout.pipe(dest as Writable)
       return this
     }
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,6 +17,8 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { chalk } from './vendor-core.js'
 
+export { isStringLiteral } from './vendor-core.js'
+
 export function tempdir(prefix = `zx-${randomId()}`) {
   const dirpath = path.join(os.tmpdir(), prefix)
   fs.mkdirSync(dirpath, { recursive: true })

--- a/src/vendor-core.ts
+++ b/src/vendor-core.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export { exec, buildCmd, type TSpawnStore } from 'zurk/spawn'
+export { exec, buildCmd, isStringLiteral, type TSpawnStore } from 'zurk/spawn'
 
 export type RequestInfo = Parameters<typeof globalThis.fetch>[0]
 export type RequestInit = Parameters<typeof globalThis.fetch>[1]


### PR DESCRIPTION
Enables [zurk-like](https://github.com/webpod/zurk/blob/main/src/test/ts/x.test.ts#L143) pipe literals:

<!-- Usage demo -->
```js
const p = await $`echo foo`.pipe`cat`
assert.equal(p.stdout.trim(), 'foo')
```
- [x] Tests pass

