### PR TITLE
feat(cli): allow overriding default script extension

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -30,7 +30,7 @@
   {
     "name": "all",
     "path": "build/*",
-    "limit": "833.1 kB",
+    "limit": "833.6 kB",
     "brotli": false,
     "gzip": false
   }

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -30,7 +30,7 @@
   {
     "name": "all",
     "path": "build/*",
-    "limit": "833 kB",
+    "limit": "833.1 kB",
     "brotli": false,
     "gzip": false
   }

--- a/man/zx.1
+++ b/man/zx.1
@@ -21,6 +21,8 @@ prefix all commands
 postfix all commands
 .SS --eval=<js>, -e
 evaluate script
+.SS --ext=<.mjs>
+default extension
 .SS --install, -i
 install dependencies
 .SS --repl

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,6 +86,7 @@ export const argv = minimist(process.argv.slice(2), {
 
 export async function main() {
   await import('./globals.js')
+  argv.ext = normalizeExt(argv.ext)
   if (argv.cwd) $.cwd = argv.cwd
   if (argv.verbose) $.verbose = true
   if (argv.quiet) $.quiet = true
@@ -301,4 +302,10 @@ export function isMain(
   }
 
   return false
+}
+
+export function normalizeExt(ext?: string) {
+  if (!ext) return
+  if (!/^\.?\w+(\.\w+)*$/.test(ext)) throw new Error(`Invalid extension ${ext}`)
+  return ext[0] === '.' ? ext : `.${ext}`
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,7 @@ export function printUsage() {
    --postfix=<command>  postfix all commands
    --cwd=<path>         set current directory
    --eval=<js>, -e      evaluate script 
-   --ext=<.mjs>         eval extension
+   --ext=<.mjs>         default extension
    --install, -i        install dependencies
    --version, -v        print current zx version
    --help, -h           print help

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -20,6 +20,9 @@ import { isMain } from '../build/cli.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const spawn = $.spawn
+const nodeMajor = +process.versions?.node?.split('.')[0]
+const test22 = nodeMajor >= 22 ? test : test.skip
+
 describe('cli', () => {
   // Helps detect unresolved ProcessPromise.
   before(() => {
@@ -142,6 +145,12 @@ describe('cli', () => {
         (await fs.readFile('test/fixtures/no-extension.mjs')).toString()
       )
     )
+  })
+
+  test22('scripts from stdin with explicit extension', async () => {
+    const out =
+      await $`node --experimental-strip-types build/cli.js --ext='.ts' <<< 'const foo: string = "bar"; console.log(foo)'`
+    assert.match(out.stdout, /bar/)
   })
 
   test('require() is working from stdin', async () => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -16,7 +16,7 @@ import assert from 'node:assert'
 import { test, describe, before, after } from 'node:test'
 import { fileURLToPath } from 'node:url'
 import '../build/globals.js'
-import { isMain } from '../build/cli.js'
+import { isMain, normalizeExt } from '../build/cli.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const spawn = $.spawn
@@ -266,5 +266,12 @@ describe('cli', () => {
         assert.ok(['EACCES', 'ENOENT'].includes(e.code))
       }
     })
+  })
+
+  test('normalizeExt()', () => {
+    assert.equal(normalizeExt('.ts'), '.ts')
+    assert.equal(normalizeExt('ts'), '.ts')
+    assert.equal(normalizeExt(), undefined)
+    assert.throws(() => normalizeExt('.'))
   })
 })


### PR DESCRIPTION
closes #929

```js
NODE_OPTIONS='--experimental-strip-types' npx zx --ext='.ts' <<< 'const foo:string="bar"; console.log(foo)'
```

- [x] Tests pass

