### PR TITLE
fix: autorun halted processes on pipe run

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "zx/core",
     "path": ["build/core.cjs", "build/util.cjs", "build/vendor-core.cjs"],
-    "limit": "71.1 kB",
+    "limit": "72 kB",
     "brotli": false,
     "gzip": false
   },
@@ -30,7 +30,7 @@
   {
     "name": "all",
     "path": "build/*",
-    "limit": "833.6 kB",
+    "limit": "835 kB",
     "brotli": false,
     "gzip": false
   }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -436,6 +436,32 @@ describe('core', () => {
           assert.equal(o2, 'HELLO WORLD\n')
         })
 
+        test('$ > $ halted', async () => {
+          const $h = $({ halt: true })
+          const { stdout } = await $`echo "hello"`
+            .pipe($h`awk '{print $1" world"}'`)
+            .pipe($h`tr '[a-z]' '[A-Z]'`)
+
+          assert.equal(stdout, 'HELLO WORLD\n')
+        })
+
+        test('$ halted > $ halted', async () => {
+          const $h = $({ halt: true })
+          const { stdout } = await $h`echo "hello"`
+            .pipe($h`awk '{print $1" world"}'`)
+            .pipe($h`tr '[a-z]' '[A-Z]'`)
+            .run()
+
+          assert.equal(stdout, 'HELLO WORLD\n')
+        })
+
+        test('$ halted > $ literal', async () => {
+          const { stdout } = await $({ halt: true })`echo "hello"`
+            .pipe`awk '{print $1" world"}'`.pipe`tr '[a-z]' '[A-Z]'`.run()
+
+          assert.equal(stdout, 'HELLO WORLD\n')
+        })
+
         test('$ > stream', async () => {
           const file = tempfile()
           const fileStream = fs.createWriteStream(file)


### PR DESCRIPTION
continues #949

This part enables:
```ts
const { stdout } = await $({ halt: true })`echo "hello"`
     .pipe`awk '{print $1" world"}'`
     .pipe`tr '[a-z]' '[A-Z]'`
     .run()
```

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
