### PR TITLE
feat: let $ be piped from stream

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "zx/core",
     "path": ["build/core.cjs", "build/util.cjs", "build/vendor-core.cjs"],
-    "limit": "72 kB",
+    "limit": "73 kB",
     "brotli": false,
     "gzip": false
   },
@@ -16,7 +16,7 @@
   {
     "name": "dts libdefs",
     "path": "build/*.d.ts",
-    "limit": "36 kB",
+    "limit": "37 kB",
     "brotli": false,
     "gzip": false
   },
@@ -30,7 +30,7 @@
   {
     "name": "all",
     "path": "build/*",
-    "limit": "835 kB",
+    "limit": "840 kB",
     "brotli": false,
     "gzip": false
   }


### PR DESCRIPTION
continues #949

```ts
const getUpperCaseTransform = () =>
  new Transform({
    transform(chunk, encoding, callback) {
      callback(null, String(chunk).toUpperCase())
    },
  })
  
// $ > stream (promisified) > $ 
const o1 = await $`echo "hello"`
   .pipe(getUpperCaseTransform())
   .pipe($`cat`)
   
o1.stdout //  'HELLO\n'

// stream > $
const file = tempfile()
await fs.writeFile(file, 'test')
const o2 = await fs
  .createReadStream(file)
  .pipe(getUpperCaseTransform())
  .pipe($`cat`)
  
o2.stdout //  'TEST'
```
