### PR TITLE
fix: mixin `ProcessOutput` data to promisified pipe value

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -449,3 +449,16 @@ export const once = <T extends (...args: any[]) => any>(fn: T) => {
     return (result = fn(...args))
   }
 }
+
+export const proxyOverride = <T extends object>(
+  origin: T,
+  ...fallbacks: any
+): T =>
+  new Proxy(origin, {
+    get(target: T, key) {
+      return (
+        fallbacks.find((f: any) => key in f)?.[key] ??
+        Reflect.get(target as T, key)
+      )
+    },
+  }) as T

--- a/test-d/core.test-d.ts
+++ b/test-d/core.test-d.ts
@@ -27,9 +27,9 @@ expectType<ProcessPromise>(p.nothrow())
 expectType<ProcessPromise>(p.quiet())
 expectType<ProcessPromise>(p.pipe($`cmd`))
 expectType<ProcessPromise>(p.pipe`cmd`)
-expectType<typeof process.stdout & PromiseLike<typeof process.stdout>>(
-  p.pipe(process.stdout)
-)
+expectType<
+  typeof process.stdout & PromiseLike<ProcessOutput & typeof process.stdout>
+>(p.pipe(process.stdout))
 expectType<ProcessPromise>(p.stdio('pipe'))
 expectType<ProcessPromise>(p.timeout('1s'))
 expectType<Promise<void>>(p.kill())

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -475,11 +475,19 @@ describe('core', () => {
           const p = $`echo "hello"`
             .pipe(getUpperCaseTransform())
             .pipe(fileStream)
+          const o = await p
 
           assert.ok(p instanceof WriteStream)
-          assert.equal(await p, fileStream)
+          assert.ok(o instanceof WriteStream)
+          assert.equal(o.stdout, 'hello\n')
+          assert.equal(o.exitCode, 0)
           assert.equal((await fs.readFile(file)).toString(), 'HELLO\n')
           await fs.rm(file)
+        })
+
+        test('$ > stdout', async () => {
+          const p = $`echo 1`.pipe(process.stdout)
+          assert.deepEqual(p, process.stdout)
         })
 
         test('$ halted > stream', async () => {
@@ -513,11 +521,6 @@ describe('core', () => {
           const { stdout } = await p.pipe(getUpperCaseTransform()).pipe($`cat`)
 
           assert.equal(stdout, 'HELLO\n')
-        })
-
-        test('$ > stdout', async () => {
-          const p = $`echo 1`.pipe(process.stdout)
-          assert.equal(await p, process.stdout)
         })
       })
 


### PR DESCRIPTION
continues #949

Promisified pipe result exposes the closest left `ProcessOutput` data for backward compatibility

```ts
const file = tempfile()
const fileStream = fs.createWriteStream(file)
const p = $`echo "hello"`
  .pipe(getUpperCaseTransform())
  .pipe(fileStream)
const o = await p

assert.ok(p instanceof WriteStream)
assert.ok(o instanceof WriteStream)
assert.equal(o.stdout, 'hello\n')
assert.equal(o.exitCode, 0)
assert.equal((await fs.readFile(file)).toString(), 'HELLO\n')
```

- [x] Tests pass
