### PR TITLE
feat: direct piping to file shortcut

### DIFF
--- a/docs/process-promise.md
+++ b/docs/process-promise.md
@@ -70,6 +70,13 @@ await $`echo "Hello, stdout!"`
 await $`cat /tmp/output.txt`
 ```
 
+You can pass a string to `pipe()` to implicitly create a receiving file. The previous example is equivalent to:
+
+```js
+await $`echo "Hello, stdout!"`
+  .pipe('/tmp/output.txt')
+```
+
 Pipes can be used to show a real-time output of the process:
 
 ```js

--- a/src/core.ts
+++ b/src/core.ts
@@ -333,7 +333,7 @@ export class ProcessPromise extends Promise<ProcessOutput> {
   pipe<D extends Writable>(dest: D): D & PromiseLike<ProcessOutput & D>
   pipe<D extends ProcessPromise>(dest: D): D
   pipe(
-    dest: Writable | ProcessPromise | TemplateStringsArray,
+    dest: Writable | ProcessPromise | TemplateStringsArray | string,
     ...args: any[]
   ): (Writable & PromiseLike<ProcessPromise & Writable>) | ProcessPromise {
     if (isStringLiteral(dest, ...args))
@@ -344,9 +344,6 @@ export class ProcessPromise extends Promise<ProcessOutput> {
           signal: this._snapshot.signal,
         })(dest as TemplateStringsArray, ...args)
       )
-
-    if (isString(dest))
-      throw new Error('The pipe() method does not take strings. Forgot $?')
 
     this._piped = true
     const ee = this._ee
@@ -369,6 +366,8 @@ export class ProcessPromise extends Promise<ProcessOutput> {
       })
     }
 
+    if (isString(dest)) dest = fs.createWriteStream(dest)
+
     if (dest instanceof ProcessPromise) {
       dest._pipedFrom = this
 
@@ -380,6 +379,7 @@ export class ProcessPromise extends Promise<ProcessOutput> {
       }
       return dest
     }
+
     from.once('end', () => dest.emit('end-piped-from')).pipe(dest)
     return promisifyStream(dest, this) as Writable &
       PromiseLike<ProcessPromise & Writable>

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -395,6 +395,20 @@ describe('core', () => {
         }
       })
 
+      test('accepts file', async () => {
+        const file = tempfile()
+        try {
+          await $`echo foo`.pipe(file)
+          assert.equal((await fs.readFile(file)).toString(), 'foo\n')
+
+          const r = $`cat`
+          fs.createReadStream(file).pipe(r.stdin)
+          assert.equal((await r).stdout, 'foo\n')
+        } finally {
+          await fs.rm(file)
+        }
+      })
+
       test('accepts ProcessPromise', async () => {
         const p = await $`echo foo`.pipe($`cat`)
         assert.equal(p.stdout.trim(), 'foo')
@@ -409,19 +423,6 @@ describe('core', () => {
         const p1 = $`echo pipe-to-stdout`
         const p2 = p1.pipe(process.stdout)
         assert.equal((await p1).stdout.trim(), 'pipe-to-stdout')
-      })
-
-      test('checks argument type', async () => {
-        let err
-        try {
-          $`echo 'test'`.pipe('str')
-        } catch (p) {
-          err = p
-        }
-        assert.equal(
-          err.message,
-          'The pipe() method does not take strings. Forgot $?'
-        )
       })
 
       describe('supports chaining', () => {


### PR DESCRIPTION
Now, instead of

```js
await $`echo "Hello, stdout!"`
  .pipe(fs.createWriteStream('/tmp/output.txt'))
```

you can simply do

```js
await $`echo "Hello, stdout!"`
  .pipe('/tmp/output.txt')
```

Fixes #976

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
