### PR TITLE
fix: disable spinner in CI

### DIFF
--- a/scripts/build-tests.mjs
+++ b/scripts/build-tests.mjs
@@ -44,6 +44,7 @@ apis.forEach((name) => {
     : ''
   fileContents += `
 describe('vendor ${name} API ', () => {
+  // prettier-ignore
   test('exports', () => {
     assert.equal(typeof ${name}, '${typeof api}')${methodChecks}
   })

--- a/src/goods.ts
+++ b/src/goods.ts
@@ -175,6 +175,8 @@ export async function spinner<T>(
     callback = title
     title = ''
   }
+  if (process.env.CI) return callback!()
+
   let i = 0
   const spin = () =>
     process.stderr.write(`  ${'⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'[i++ % 10]} ${title}\r`)

--- a/test/goods.test.js
+++ b/test/goods.test.js
@@ -132,31 +132,51 @@ describe('goods', () => {
     assert.ok(Date.now() >= now + 2 + 4 + 8 + 16 + 32)
   })
 
-  test('spinner() works', async () => {
-    const out = await zx(`
+  describe('spinner()', () => {
+    test('works', async () => {
+      const out = await zx(
+        `
+    process.env.CI = ''
     echo(await spinner(async () => {
       await sleep(100)
       await $\`echo hidden\`
       return $\`echo result\`
     }))
-  `)
-    assert(out.stdout.includes('result'))
-    assert(!out.stderr.includes('result'))
-    assert(!out.stderr.includes('hidden'))
-  })
+  `,
+        { CI: '' }
+      )
+      assert(out.stdout.includes('result'))
+      assert(out.stderr.includes('⠋'))
+      assert(!out.stderr.includes('result'))
+      assert(!out.stderr.includes('hidden'))
+    })
 
-  test('spinner() with title works', async () => {
-    const out = await zx(`
+    test('with title', async () => {
+      const out = await zx(
+        `
+    process.env.CI = ''
     await spinner('processing', () => sleep(100))
-  `)
-    assert.match(out.stderr, /processing/)
-  })
+  `
+      )
+      assert.match(out.stderr, /processing/)
+    })
 
-  test('spinner() stops on throw', async () => {
-    const out = await zx(`
+    test('disabled in CI', async () => {
+      const out = await zx(
+        `
+    process.env.CI = 'true'
+    await spinner('processing', () => sleep(100))
+  `
+      )
+      assert.doesNotMatch(out.stderr, /processing/)
+    })
+
+    test('stops on throw', async () => {
+      const out = await zx(`
     await spinner('processing', () => $\`wtf-cmd\`)
   `)
-    assert.match(out.stderr, /Error:/)
-    assert(out.exitCode !== 0)
+      assert.match(out.stderr, /Error:/)
+      assert(out.exitCode !== 0)
+    })
   })
 })

--- a/test/goods.test.js
+++ b/test/goods.test.js
@@ -142,8 +142,7 @@ describe('goods', () => {
       await $\`echo hidden\`
       return $\`echo result\`
     }))
-  `,
-        { CI: '' }
+  `
       )
       assert(out.stdout.includes('result'))
       assert(out.stderr.includes('⠋'))

--- a/test/vendor-export.test.js
+++ b/test/vendor-export.test.js
@@ -25,6 +25,7 @@ import {
 } from '../build/vendor.js'
 
 describe('vendor chalk API ', () => {
+  // prettier-ignore
   test('exports', () => {
     assert.equal(typeof chalk, 'function')
     assert.equal(typeof chalk.level, 'number', 'chalk.level')
@@ -32,12 +33,14 @@ describe('vendor chalk API ', () => {
 })
 
 describe('vendor depseek API ', () => {
+  // prettier-ignore
   test('exports', () => {
     assert.equal(typeof depseek, 'function')
   })
 })
 
 describe('vendor fs API ', () => {
+  // prettier-ignore
   test('exports', () => {
     assert.equal(typeof fs, 'object')
     assert.equal(typeof fs.default, 'object', 'fs.default')
@@ -56,11 +59,7 @@ describe('vendor fs API ', () => {
     assert.equal(typeof fs.cp, 'function', 'fs.cp')
     assert.equal(typeof fs.cpSync, 'function', 'fs.cpSync')
     assert.equal(typeof fs.createReadStream, 'function', 'fs.createReadStream')
-    assert.equal(
-      typeof fs.createWriteStream,
-      'function',
-      'fs.createWriteStream'
-    )
+    assert.equal(typeof fs.createWriteStream, 'function', 'fs.createWriteStream')
     assert.equal(typeof fs.exists, 'function', 'fs.exists')
     assert.equal(typeof fs.existsSync, 'function', 'fs.existsSync')
     assert.equal(typeof fs.fchown, 'function', 'fs.fchown')
@@ -167,17 +166,9 @@ describe('vendor fs API ', () => {
     assert.equal(typeof fs.ensureLink, 'function', 'fs.ensureLink')
     assert.equal(typeof fs.ensureLinkSync, 'function', 'fs.ensureLinkSync')
     assert.equal(typeof fs.createSymlink, 'function', 'fs.createSymlink')
-    assert.equal(
-      typeof fs.createSymlinkSync,
-      'function',
-      'fs.createSymlinkSync'
-    )
+    assert.equal(typeof fs.createSymlinkSync, 'function', 'fs.createSymlinkSync')
     assert.equal(typeof fs.ensureSymlink, 'function', 'fs.ensureSymlink')
-    assert.equal(
-      typeof fs.ensureSymlinkSync,
-      'function',
-      'fs.ensureSymlinkSync'
-    )
+    assert.equal(typeof fs.ensureSymlinkSync, 'function', 'fs.ensureSymlinkSync')
     assert.equal(typeof fs.readJson, 'function', 'fs.readJson')
     assert.equal(typeof fs.readJsonSync, 'function', 'fs.readJsonSync')
     assert.equal(typeof fs.writeJson, 'function', 'fs.writeJson')
@@ -208,12 +199,14 @@ describe('vendor fs API ', () => {
 })
 
 describe('vendor minimist API ', () => {
+  // prettier-ignore
   test('exports', () => {
     assert.equal(typeof minimist, 'function')
   })
 })
 
 describe('vendor ps API ', () => {
+  // prettier-ignore
   test('exports', () => {
     assert.equal(typeof ps, 'object')
     assert.equal(typeof ps.kill, 'function', 'ps.kill')
@@ -225,6 +218,7 @@ describe('vendor ps API ', () => {
 })
 
 describe('vendor which API ', () => {
+  // prettier-ignore
   test('exports', () => {
     assert.equal(typeof which, 'function')
     assert.equal(typeof which.sync, 'function', 'which.sync')
@@ -232,6 +226,7 @@ describe('vendor which API ', () => {
 })
 
 describe('vendor YAML API ', () => {
+  // prettier-ignore
   test('exports', () => {
     assert.equal(typeof YAML, 'object')
     assert.equal(typeof YAML.Alias, 'function', 'YAML.Alias')
@@ -259,11 +254,7 @@ describe('vendor YAML API ', () => {
     assert.equal(typeof YAML.isScalar, 'function', 'YAML.isScalar')
     assert.equal(typeof YAML.isSeq, 'function', 'YAML.isSeq')
     assert.equal(typeof YAML.parse, 'function', 'YAML.parse')
-    assert.equal(
-      typeof YAML.parseAllDocuments,
-      'function',
-      'YAML.parseAllDocuments'
-    )
+    assert.equal(typeof YAML.parseAllDocuments, 'function', 'YAML.parseAllDocuments')
     assert.equal(typeof YAML.parseDocument, 'function', 'YAML.parseDocument')
     assert.equal(typeof YAML.stringify, 'function', 'YAML.stringify')
     assert.equal(typeof YAML.visit, 'function', 'YAML.visit')


### PR DESCRIPTION
closes #1008

```ts
export async function spinner<T>(
  title: string | (() => T),
  callback?: () => T
): Promise<T> {
  if (typeof title == 'function') {
    callback = title
    title = ''
  }
  if (process.env.CI) return callback!()
```

- [x] Tests pass

