### PR TITLE
feat: add support env files

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,7 @@ import {
   parseArgv,
 } from './index.js'
 import { installDeps, parseDeps } from './deps.js'
-import { randomId } from './util.js'
+import { prepareEnv, randomId } from './util.js'
 import { createRequire } from './vendor.js'
 
 const EXT = '.mjs'
@@ -66,6 +66,7 @@ export function printUsage() {
    --version, -v        print current zx version
    --help, -h           print help
    --repl               start repl
+   --env=<path>         path to env file
    --experimental       enables experimental features (deprecated)
 
  ${chalk.italic('Full documentation:')} ${chalk.underline('https://google.github.io/zx/')}
@@ -74,7 +75,7 @@ export function printUsage() {
 
 // prettier-ignore
 export const argv = parseArgv(process.argv.slice(2), {
-  string: ['shell', 'prefix', 'postfix', 'eval', 'cwd', 'ext', 'registry'],
+  string: ['shell', 'prefix', 'postfix', 'eval', 'cwd', 'ext', 'registry', 'env'],
   boolean: ['version', 'help', 'quiet', 'verbose', 'install', 'repl', 'experimental', 'prefer-local'],
   alias: { e: 'eval', i: 'install', v: 'version', h: 'help', l: 'prefer-local' },
   stopEarly: true,
@@ -86,6 +87,12 @@ export async function main() {
   await import('./globals.js')
   argv.ext = normalizeExt(argv.ext)
   if (argv.cwd) $.cwd = argv.cwd
+  if (argv.env) {
+    const processRootDir =
+      argv?.cwd ?? path.dirname(new URL(import.meta.url).pathname)
+    const envPath = path.resolve(processRootDir, argv.env)
+    process.env = prepareEnv(envPath, process.env)
+  }
   if (argv.verbose) $.verbose = true
   if (argv.quiet) $.quiet = true
   if (argv.shell) $.shell = argv.shell

--- a/src/util.ts
+++ b/src/util.ts
@@ -357,3 +357,43 @@ export const toCamelCase = (str: string) =>
 
 export const parseBool = (v: string): boolean | string =>
   ({ true: true, false: false })[v] ?? v
+
+// prettier-ignore
+export const parseEnvFromFile = (
+    content: string,
+  ): NodeJS.ProcessEnv => {
+    return content
+      .split(/\r?\n/)
+      .reduce<NodeJS.ProcessEnv>((acc, line) => {
+        const cleanedLine = line.replace(/[\r?\n]+/g, '').trim();
+        const key = cleanedLine.split("=", 1)?.[0];
+
+        if (!key) return acc;
+
+        const value = cleanedLine.slice(key.length + 1);
+
+        if (!value) return acc;
+
+        acc[key] = value;
+
+        return acc;
+      }, {});
+  };
+
+export const prepareEnv = (
+  filepath: string,
+  env: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv => {
+  try {
+    const content = fs.readFileSync(path.resolve(filepath), {
+      encoding: 'utf8',
+    })
+
+    return {
+      ...env,
+      ...parseEnvFromFile(content),
+    }
+  } catch (e) {
+    return env
+  }
+}

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -150,6 +150,42 @@ describe('cli', () => {
     assert.ok(p.stderr.endsWith(cwd + '\n'))
   })
 
+  test('supports `--env` options with file', async () => {
+    const env = tmpfile(
+      '.env',
+      `FOO=BAR
+      BAR=FOO+=`
+    )
+    const file = tmpfile(
+      'index.mjs',
+      'console.log(process.env.FOO);\nconsole.log(process.env.BAR)'
+    )
+
+    const out = await $`node build/cli.js --env=${env} ${file}`
+    fs.remove(env)
+    fs.remove(file)
+    assert.equal(out.stdout, 'BAR\nFOO+=\n')
+  })
+
+  test('supports `--env` and `--cwd` options and with file', async () => {
+    const cwd = path.resolve(fileURLToPath(import.meta.url), '../../temp')
+    fs.mkdirSync(cwd, { recursive: true })
+    const env = tmpfile(
+      '.env',
+      `FOO=BAR
+      BAR=FOO+=`
+    )
+    const file = tmpfile(
+      'index.mjs',
+      'console.log(process.env.FOO);\nconsole.log(process.env.BAR)'
+    )
+
+    const out = await $`node build/cli.js --cwd=${cwd} --env=${env} ${file}`
+    fs.remove(env)
+    fs.remove(file)
+    assert.equal(out.stdout, 'BAR\nFOO+=\n')
+  })
+
   test('scripts from https 200', async () => {
     const resp = await fs.readFile(path.resolve('test/fixtures/echo.http'))
     const port = await getPort()

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -139,3 +139,35 @@ describe('util', () => {
     assert.equal(toCamelCase('kebab-input-str'), 'kebabInputStr')
   })
 })
+
+test('parseEnvFromFile()', () => {
+  assert.deepEqual(parseEnvFromFile('ENV=value1\nENV2=value24=f]fdsd'), {
+    ENV: 'value1',
+    ENV2: 'value24=f]fdsd',
+  })
+  assert.deepEqual(parseEnvFromFile('ENV=value1\nENV2=value24'), {
+    ENV: 'value1',
+    ENV2: 'value24',
+  })
+  assert.deepEqual(parseEnvFromFile(''), {})
+})
+
+describe('prepareEnv()', () => {
+  test('handles correct proccess.env', () => {
+    const file = tempfile('.env', 'ENV=value1\nENV2=value24=f]fdsd')
+    const env = prepareEnv(file)
+    assert.equal(env.ENV, 'value1')
+    assert.equal(env.ENV2, 'value24=f]fdsd')
+    assert.ok(env.NODE_VERSION !== '')
+  })
+
+  test('handles correct some env', () => {
+    const file = tempfile('.env', 'ENV=value1\nENV2=value24=f]fdsd')
+    const env = prepareEnv(file, { version: '1.0.0', name: 'zx' })
+    assert.equal(env.ENV, 'value1')
+    assert.equal(env.ENV2, 'value24=f]fdsd')
+    assert.equal(env.ENV2, 'value24=f]fdsd')
+    assert.equal(env.version, '1.0.0')
+    assert.equal(env.name, 'zx')
+  })
+})


### PR DESCRIPTION
Fixes  #974

```js
zx --env=/path/to/some.env my-script.mjs
```

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
