### PR TITLE
feat: enable stream picking on `pipe()`

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "zx/core",
     "path": ["build/core.cjs", "build/util.cjs", "build/vendor-core.cjs"],
-    "limit": "75 kB",
+    "limit": "76 kB",
     "brotli": false,
     "gzip": false
   },
@@ -30,7 +30,7 @@
   {
     "name": "all",
     "path": "build/*",
-    "limit": "840 kB",
+    "limit": "841 kB",
     "brotli": false,
     "gzip": false
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -349,21 +349,18 @@ export class ProcessPromise extends Promise<ProcessOutput> {
   }
   // prettier-ignore
   static {
-    Object.defineProperty(this.prototype, 'pipe', {
-      get() {
-        const self = this
-        const pipeStdout: PipeMethod = function (dest: PipeDest, ...args: any[]) { return self._pipe.call(self,'stdout', dest, ...args) }
-        const pipeStderr: PipeMethod = function (dest: PipeDest, ...args: any[]) { return self._pipe.call(self,'stderr', dest, ...args) }
-        return Object.assign(pipeStdout, { stderr: pipeStderr, stdout: pipeStdout })
-      },
-    })
+    Object.defineProperty(this.prototype, 'pipe', { get() {
+      const self = this
+      const pipeStdout: PipeMethod = function (dest: PipeDest, ...args: any[]) { return self._pipe.call(self, 'stdout', dest, ...args) }
+      const pipeStderr: PipeMethod = function (dest: PipeDest, ...args: any[]) { return self._pipe.call(self, 'stderr', dest, ...args) }
+      return Object.assign(pipeStdout, { stderr: pipeStderr, stdout: pipeStdout })
+    }})
   }
   private _pipe(
-    this: ProcessPromise,
     source: 'stdout' | 'stderr',
     dest: PipeDest,
     ...args: any[]
-  ): any {
+  ): (Writable & PromiseLike<ProcessPromise & Writable>) | ProcessPromise {
     if (isStringLiteral(dest, ...args))
       return this.pipe[source](
         $({

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -34,6 +34,7 @@ import {
   usePwsh,
   useBash,
 } from '../build/core.js'
+import { which } from '../build/vendor.js'
 
 describe('core', () => {
   describe('resolveDefaults()', () => {
@@ -613,6 +614,15 @@ describe('core', () => {
         assert.equal(r1.value.exitCode, 0)
         assert.equal(r2.reason.stdout, 'foo\n')
         assert.equal(r2.reason.exitCode, 1)
+      })
+
+      test('pipes particular stream: stdout ot stderr', async () => {
+        const p = $`echo foo >&2; echo bar`
+        const o1 = (await p.pipe.stderr`cat`).toString()
+        const o2 = (await p.pipe.stdout`cat`).toString()
+
+        assert.equal(o1, 'foo\n')
+        assert.equal(o2, 'bar\n')
       })
     })
 


### PR DESCRIPTION
Closes #978 

<!-- Usage demo -->
```js
  const p = $`echo foo >&2; echo bar`
  const o1 = (await p.pipe.stderr`cat`).toString()
  const o2 = (await p.pipe.stdout`cat`).toString()
  
  assert.equal(o1, 'foo\n')
  assert.equal(o2, 'bar\n')
```

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
