### PR TITLE
fix: let `shell` path be preconfigured via env

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -890,6 +890,7 @@ export function resolveDefaults(
     'timeoutSignal',
     'prefix',
     'postfix',
+    'shell',
   ])
 
   return Object.entries(env).reduce<Options>((m, [k, v]) => {


### PR DESCRIPTION
- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
