### PR TITLE
feat: provide support for .env files injects via API

### DIFF
--- a/docs/v7/api.md
+++ b/docs/v7/api.md
@@ -204,3 +204,17 @@ The [yaml](https://www.npmjs.com/package/yaml) package.
 ```js
 console.log(YAML.parse('foo: bar').foo)
 ```
+
+
+## loadDotenv
+
+Read env files and collects it into environment variables.
+
+```js
+const env = loadDotenv(env1, env2)
+console.log((await $({ env })`echo $FOO`).stdout)
+---
+const env = loadDotenv(env1)
+$.env = env
+console.log((await $`echo $FOO`).stdout)
+```

--- a/src/goods.ts
+++ b/src/goods.ts
@@ -21,6 +21,7 @@ import {
   isStringLiteral,
   parseBool,
   parseDuration,
+  readEnvFromFile,
   toCamelCase,
 } from './util.js'
 import {
@@ -217,3 +218,10 @@ export async function spinner<T>(
     }
   })
 }
+
+/**
+ *
+ * Read env files and collects it into environment variables
+ */
+export const loadDotenv = (...files: string[]): NodeJS.ProcessEnv =>
+  files.reduce<NodeJS.ProcessEnv>((m, f) => readEnvFromFile(f, m), {})

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -17,21 +17,8 @@ import { test, describe, before, after } from 'node:test'
 import { fileURLToPath } from 'node:url'
 import net from 'node:net'
 import getPort from 'get-port'
-import {
-  argv,
-  importPath,
-  injectGlobalRequire,
-  isMain,
-  main,
-  normalizeExt,
-  runScript,
-  printUsage,
-  scriptFromStdin,
-  scriptFromHttp,
-  transformMarkdown,
-  writeAndImport,
-} from '../build/cli.js'
-import { $, path, fs, tmpfile, tmpdir } from '../build/index.js'
+import { $, path, tmpfile, tmpdir, fs } from '../build/index.js'
+import { isMain, normalizeExt, transformMarkdown } from '../build/cli.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const spawn = $.spawn

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -26,24 +26,20 @@ import {
   resolveDefaults,
   cd,
   syncProcessCwd,
-  log,
-  kill,
-  defaults,
   within,
   usePowerShell,
   usePwsh,
   useBash,
 } from '../build/core.js'
 import {
-  fs,
-  nothrow,
-  quiet,
-  sleep,
   tempfile,
-  tempdir,
-  which,
+  fs,
+  quote,
+  quotePowerShell,
+  sleep,
+  quiet,
+  which
 } from '../build/index.js'
-import { quote, quotePowerShell } from '../build/util.js'
 
 describe('core', () => {
   describe('resolveDefaults()', () => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -38,7 +38,7 @@ import {
   quotePowerShell,
   sleep,
   quiet,
-  which
+  which,
 } from '../build/index.js'
 
 describe('core', () => {

--- a/test/export.test.js
+++ b/test/export.test.js
@@ -331,6 +331,7 @@ describe('index', () => {
     assert.equal(typeof index.globby.isGitIgnored, 'function', 'index.globby.isGitIgnored')
     assert.equal(typeof index.globby.isGitIgnoredSync, 'function', 'index.globby.isGitIgnoredSync')
     assert.equal(typeof index.kill, 'function', 'index.kill')
+    assert.equal(typeof index.loadDotenv, 'function', 'index.loadDotenv')
     assert.equal(typeof index.log, 'function', 'index.log')
     assert.equal(typeof index.minimist, 'function', 'index.minimist')
     assert.equal(typeof index.nothrow, 'function', 'index.nothrow')

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -14,7 +14,8 @@
 
 import assert from 'node:assert'
 import fs from 'node:fs'
-import { test, describe } from 'node:test'
+import { test, describe, after } from 'node:test'
+import { fs as fsCore } from '../build/index.js'
 import {
   formatCmd,
   isString,
@@ -164,8 +165,10 @@ e.g. a private SSH key
 })
 
 describe('readEnvFromFile()', () => {
+  const file = tempfile('.env', 'ENV=value1\nENV2=value24')
+  after(() => fsCore.remove(file))
+
   test('handles correct proccess.env', () => {
-    const file = tempfile('.env', 'ENV=value1\nENV2=value24')
     const env = readEnvFromFile(file)
     assert.equal(env.ENV, 'value1')
     assert.equal(env.ENV2, 'value24')

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -176,7 +176,6 @@ describe('readEnvFromFile()', () => {
   })
 
   test('handles correct some env', () => {
-    const file = tempfile('.env', 'ENV=value1\nENV2=value24')
     const env = readEnvFromFile(file, { version: '1.0.0', name: 'zx' })
     assert.equal(env.ENV, 'value1')
     assert.equal(env.ENV2, 'value24')


### PR DESCRIPTION
Fixes #975

<!-- Usage demo -->
```js
/// './path/prod.env'
FOO=BAR

---
/// index.js
$.env = './path/prod.env'
await $`echo $FOO`.stdout // BAR
```

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
