### PR TITLE
feat: expose ProcessPromise `fullCmd` and unique `id`

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -16,7 +16,7 @@
   {
     "name": "dts libdefs",
     "path": "build/*.d.ts",
-    "limit": "37.1 kB",
+    "limit": "37.5 kB",
     "brotli": false,
     "gzip": false
   },

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -392,11 +392,13 @@ describe('core', () => {
       const baz = 1
       const p = $`echo ${foo} --t ${baz}`
       assert.equal(p.cmd, "echo $'#bar' --t 1")
+      assert.equal(p.fullCmd, "set -euo pipefail;echo $'#bar' --t 1")
     })
 
-    test('exposes pid', () => {
+    test('exposes pid & id', () => {
       const p = $`echo foo`
       assert.ok(p.pid > 0)
+      assert.ok(typeof p.id === 'string')
     })
 
     test('stdio() works', async () => {


### PR DESCRIPTION
relates #1028

<!-- Usage demo -->
```js
const foo = '#bar'
const baz = 1
const p = $`echo ${foo} --t ${baz}`
p.cmd       // "echo $'#bar' --t 1")
p.fullCmd   // "set -euo pipefail;echo $'#bar' --t 1"
```

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
