### PR TITLE
feat(cli): alias `env-file` and `env` options

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,7 +77,7 @@ export function printUsage() {
 export const argv = parseArgv(process.argv.slice(2), {
   string: ['shell', 'prefix', 'postfix', 'eval', 'cwd', 'ext', 'registry', 'env'],
   boolean: ['version', 'help', 'quiet', 'verbose', 'install', 'repl', 'experimental', 'prefer-local'],
-  alias: { e: 'eval', i: 'install', v: 'version', h: 'help', l: 'prefer-local' },
+  alias: { e: 'eval', i: 'install', v: 'version', h: 'help', l: 'prefer-local', 'env-file': 'env' },
   stopEarly: true,
   parseBoolean: true,
   camelCase: true,


### PR DESCRIPTION
A bit more consistency with nodejs
https://nodejs.org/en/learn/command-line/how-to-read-environment-variables-from-nodejs

```bash
zx --env-file='.env' script.mjs
```

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
