### PR TITLE
fix(core): handle `timeout` setting for halted, resolved and sync processes

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -9,7 +9,7 @@
   {
     "name": "zx/index",
     "path": "build/*.{js,cjs}",
-    "limit": "806 kB",
+    "limit": "807 kB",
     "brotli": false,
     "gzip": false
   },

--- a/docs/api.md
+++ b/docs/api.md
@@ -75,22 +75,26 @@ interface Options {
   signal:         AbortSignal
   input:          string | Buffer | Readable | ProcessOutput | ProcessPromise
   timeout:        Duration
-  timeoutSignal:  string
+  timeoutSignal:  NodeJS.Signals
   stdio:          StdioOptions
   verbose:        boolean
   sync:           boolean
   env:            NodeJS.ProcessEnv
-  shell:          string | boolean
+  shell:          string | true
   nothrow:        boolean
   prefix:         string
   postfix:        string
   quote:          typeof quote
   quiet:          boolean
   detached:       boolean
+  preferLocal:    boolean | string | string[]
   spawn:          typeof spawn
   spawnSync:      typeof spawnSync
+  store:          TSpawnStore
   log:            typeof log
   kill:           typeof kill
+  killSignal:     NodeJS.Signals
+  halt:           boolean
 }
 ```
 


### PR DESCRIPTION
* fix: ignore `timeout` setting for sync or resolved processes
* fix: invoke `setTimeout` if process is running

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
