### PR TITLE
fix: allow default `killSignal` setting via env

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -902,6 +902,7 @@ export function resolveDefaults(
     'quiet',
     'timeout',
     'timeoutSignal',
+    'killSignal',
     'prefix',
     'postfix',
     'shell',


### PR DESCRIPTION
- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
