### PR TITLE
feat: make `nothrow()` toggleable

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -501,8 +501,8 @@ export class ProcessPromise extends Promise<ProcessOutput> {
     return this
   }
 
-  nothrow(): ProcessPromise {
-    this._nothrow = true
+  nothrow(v = true): ProcessPromise {
+    this._nothrow = v
     return this
   }
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -33,12 +33,14 @@ import {
 } from '../build/core.js'
 import {
   tempfile,
+  tempdir,
   fs,
   quote,
   quotePowerShell,
   sleep,
   quiet,
   which,
+  nothrow,
 } from '../build/index.js'
 
 describe('core', () => {
@@ -939,6 +941,15 @@ describe('core', () => {
     test('nothrow() does not throw', async () => {
       const { exitCode } = await $`exit 42`.nothrow()
       assert.equal(exitCode, 42)
+      {
+        // Toggle
+        try {
+          const p = $`exit 42`.nothrow()
+          await p.nothrow(false)
+        } catch ({ exitCode }) {
+          assert.equal(exitCode, 42)
+        }
+      }
       {
         // Deprecated.
         const { exitCode } = await nothrow($`exit 42`)


### PR DESCRIPTION
closes #1029

```js
try {
  const p = $`exit 42`.nothrow()
  await p.nothrow(false)
} catch ({ exitCode }) {
  assert.equal(exitCode, 42)
}
```

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
