### PR TITLE
ci: update osv scanner action

### DIFF
--- a/.github/workflows/osv.yml
+++ b/.github/workflows/osv.yml
@@ -27,7 +27,8 @@ jobs:
     permissions:
       security-events: write
       contents: read
-    uses: 'google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78' # v1.7.1
+      actions: read
+    uses: 'google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@126676819209c3a606f31bc46ad974fba4f2012c' # v1.9.2
     with:
       # Example of specifying custom arguments
       scan-args: |-
@@ -39,7 +40,8 @@ jobs:
     permissions:
       security-events: write
       contents: read
-    uses: 'google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@1f1242919d8a60496dd1874b24b62b2370ed4c78' # v1.7.1
+      actions: read
+    uses: 'google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@126676819209c3a606f31bc46ad974fba4f2012c' # v1.9.2
     with:
       # Example of specifying custom arguments
       scan-args: |-


### PR DESCRIPTION
* https://github.com/webpod/envapi/actions/runs/13058739080/job/36436234663#step:1:25
* https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

<img width="978" alt="image" src="https://github.com/user-attachments/assets/f4a50fcd-decb-4644-ab6e-a7b29e76c855" />
