### PR TITLE
fix: check user input on `dotenv.stringify`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zx",
-  "version": "8.4.0",
+  "version": "8.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zx",
-      "version": "8.4.0",
+      "version": "8.3.2",
       "license": "Apache-2.0",
       "bin": {
         "zx": "build/cli.js"
@@ -25,7 +25,7 @@
         "cronometro": "^4.0.3",
         "depseek": "^0.4.1",
         "dts-bundle-generator": "^9.5.1",
-        "envapi": "^0.2.1",
+        "envapi": "^0.2.3",
         "esbuild": "^0.24.2",
         "esbuild-node-externals": "^1.16.0",
         "esbuild-plugin-entry-chunks": "^0.1.15",
@@ -3030,9 +3030,9 @@
       }
     },
     "node_modules/envapi": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/envapi/-/envapi-0.2.1.tgz",
-      "integrity": "sha512-gWPqNxnV4PltW0jJk8qNGD7LVU5rXvZPNYt0kwLjKTNOYUkFeLjykpeNpXQycTSGdTgqj8r7tQDJIre62t9tJw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/envapi/-/envapi-0.2.3.tgz",
+      "integrity": "sha512-kSPSecU+/eH0IajEYZ/LndeBjzSBmLyp/SZFgx8Zgyeu0SoGioHkICOOVJgJLaX/rqZrCrQ+eDxiaYNVcyCsbQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zx",
-  "version": "8.4.0",
+  "version": "8.3.2",
   "description": "A tool for writing better scripts",
   "type": "module",
   "main": "./build/index.cjs",
@@ -110,7 +110,7 @@
     "cronometro": "^4.0.3",
     "depseek": "^0.4.1",
     "dts-bundle-generator": "^9.5.1",
-    "envapi": "^0.2.1",
+    "envapi": "^0.2.3",
     "esbuild": "^0.24.2",
     "esbuild-node-externals": "^1.16.0",
     "esbuild-plugin-entry-chunks": "^0.1.15",


### PR DESCRIPTION
closes #1093

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
