### PR TITLE
feat: make `ProcessOutput` iterable

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "zx/core",
     "path": ["build/core.cjs", "build/util.cjs", "build/vendor-core.cjs"],
-    "limit": "77 kB",
+    "limit": "77.5 kB",
     "brotli": false,
     "gzip": false
   },
@@ -30,7 +30,7 @@
   {
     "name": "all",
     "path": "build/*",
-    "limit": "849 kB",
+    "limit": "850 kB",
     "brotli": false,
     "gzip": false
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -758,11 +758,24 @@ export class ProcessOutput extends Error {
   }
 
   lines(): string[] {
-    return this.valueOf().split(/\r?\n/)
+    return [...this]
   }
 
   valueOf(): string {
     return this.stdall.trim()
+  }
+
+  *[Symbol.iterator](): Iterator<string> {
+    let buffer = ''
+
+    for (const chunk of this._dto.store.stdall) {
+      buffer += chunk.toString()
+      const lines = buffer.split(/\r?\n/)
+      buffer = lines.pop() ?? ''
+      yield* lines
+    }
+
+    if (buffer) yield buffer
   }
 
   static getExitMessage = formatExitMessage

--- a/src/util.ts
+++ b/src/util.ts
@@ -383,3 +383,12 @@ export const toCamelCase = (str: string) =>
 
 export const parseBool = (v: string): boolean | string =>
   ({ true: true, false: false })[v] ?? v
+
+export const getLines = (
+  chunk: Buffer | string,
+  next: (string | undefined)[]
+) => {
+  const lines = ((next.pop() || '') + bufToString(chunk)).split(/\r?\n/)
+  next.push(lines.pop())
+  return lines
+}

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1162,6 +1162,21 @@ describe('core', () => {
       globalThis.Blob = Blob
     })
 
+    test('[Symbol.Iterator]', () => {
+      const o = new ProcessOutput({
+        store: {
+          stdall: ['foo\nba', 'r\nbaz'],
+        },
+      })
+      const lines = []
+      const expected = ['foo', 'bar', 'baz']
+      for (const line of o) {
+        lines.push(line)
+      }
+      assert.deepEqual(lines, expected)
+      assert.deepEqual(o.lines(), expected)
+    })
+
     describe('static', () => {
       test('getExitMessage()', () => {
         assert.match(

--- a/test/smoke/node.test.mjs
+++ b/test/smoke/node.test.mjs
@@ -19,6 +19,7 @@ import 'zx/globals'
   {
     const p = await $`echo foo`
     assert.match(p.stdout, /foo/)
+    assert.deepEqual(p.lines(), ['foo'])
   }
 
   // captures err stack


### PR DESCRIPTION
closes #1053
closes #1027

supersedes #1088
relates #984

```js
const o = new ProcessOutput({
  store: {
    stdall: ['foo\nba', 'r\nbaz'],
  },
})
const lines = []
const expected = ['foo', 'bar', 'baz']
for (const line of o) {
  lines.push(line)
}
assert.deepEqual(lines, expected)
assert.deepEqual(o.lines(), expected)
```

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
