### PR TITLE
feat: pass origin error as `ProcessOuput` cause

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "zx/core",
     "path": ["build/core.cjs", "build/util.cjs", "build/vendor-core.cjs"],
-    "limit": "77.5 kB",
+    "limit": "77.6 kB",
     "brotli": false,
     "gzip": false
   },
@@ -30,7 +30,7 @@
   {
     "name": "all",
     "path": "build/*",
-    "limit": "850 kB",
+    "limit": "850.2 kB",
     "brotli": false,
     "gzip": false
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -675,6 +675,11 @@ type ProcessDto = {
 
 export class ProcessOutput extends Error {
   private readonly _dto: ProcessDto
+  cause!: Error | null
+  message!: string
+  stdout!: string
+  stderr!: string
+  stdall!: string
   constructor(dto: ProcessDto)
   constructor(
     code: number | null,
@@ -704,6 +709,7 @@ export class ProcessOutput extends Error {
       : { code, signal, duration, error, from, store }
 
     Object.defineProperties(this, {
+      cause: { value: dto.error, enumerable: false, writable: true, configurable: true },
       stdout: { get: once(() => bufArrJoin(dto.store.stdout)) },
       stderr: { get: once(() => bufArrJoin(dto.store.stderr)) },
       stdall: { get: once(() => bufArrJoin(dto.store.stdall)) },
@@ -715,10 +721,6 @@ export class ProcessOutput extends Error {
       },
     })
   }
-  message!: string
-  stdout!: string
-  stderr!: string
-  stdall!: string
 
   get exitCode(): number | null {
     return this._dto.code

--- a/src/goods.ts
+++ b/src/goods.ts
@@ -194,7 +194,7 @@ export async function spinner<T>(
   title: string | (() => T),
   callback?: () => T
 ): Promise<T> {
-  if (typeof title == 'function') {
+  if (typeof title === 'function') {
     callback = title
     title = ''
   }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -253,15 +253,17 @@ describe('core', () => {
         assert.equal(o1.exitCode, 1)
         assert.match(o1.message, /exit code: 1/)
 
+        const err = new Error('BrokenSpawn')
         const o2 = await $({
           nothrow: true,
           spawn() {
-            throw new Error('BrokenSpawn')
+            throw err
           },
         })`echo foo`
         assert.equal(o2.ok, false)
         assert.equal(o2.exitCode, null)
         assert.match(o2.message, /BrokenSpawn/)
+        assert.equal(o2.cause, err)
       })
 
       test('handles `input` option', async () => {


### PR DESCRIPTION
- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
