### PR TITLE
feat(log): provide custom formatting for every entry kind

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -16,7 +16,7 @@
   {
     "name": "dts libdefs",
     "path": "build/*.d.ts",
-    "limit": "39.15 kB",
+    "limit": "39.3 kB",
     "brotli": false,
     "gzip": false
   },
@@ -30,7 +30,7 @@
   {
     "name": "all",
     "path": "build/*",
-    "limit": "850.8 kB",
+    "limit": "851.1 kB",
     "brotli": false,
     "gzip": false
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,10 +108,13 @@ Set `log.output` to change the stream.
 $.log.output = process.stdout
 ```
 
-Set `log.formatCmd` to customize the command highlighter:
+Set `log.formatters` to customize each log entry kind printing:
 
 ```ts
-$.log.formatCmd = (cmd: string) => chalk.bgRedBright.black(cmd)
+$.log.formatters = {
+  cmd: (entry: LogEntry) => `CMD: ${entry.cmd}`,
+  fetch: (entry: LogEntry) => `FETCH: ${entry.url}`
+}
 ```
 
 ## `$.timeout`

--- a/src/log.ts
+++ b/src/log.ts
@@ -112,9 +112,10 @@ type Log = {
 export const log: Log = function (entry) {
   if (!entry.verbose) return
   const stream = log.output || process.stderr
-  const format = (log.formatters?.[entry.kind] ?? formatters[entry.kind]) as (
+  const format = (log.formatters?.[entry.kind] || formatters[entry.kind]) as (
     entry: LogEntry
   ) => string | Buffer
+  if (!format) return // ignore unknown log entries
   const data = format(entry)
   stream.write(data)
 }

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -27,7 +27,10 @@ describe('log', () => {
 
     before(() => (log.output = stream))
 
-    after(() => delete log.output)
+    after(() => {
+      delete log.output
+      delete log.formatters
+    })
 
     beforeEach(() => (data.length = 0))
 
@@ -87,6 +90,20 @@ describe('log', () => {
         data.join(''),
         '\x1B[41m\x1B[37m FAIL \x1B[39m\x1B[49m Attempt: 1/3; next in 1000ms\n'
       )
+    })
+
+    test('formatters', () => {
+      log.formatters = {
+        cmd: ({ cmd }) => `CMD: ${cmd}`,
+      }
+
+      log({
+        kind: 'cmd',
+        cmd: 'echo hi',
+        id: '1',
+        verbose: true,
+      })
+      assert.equal(data.join(''), 'CMD: echo hi')
     })
   })
 


### PR DESCRIPTION
continues #1122

<!-- Usage demo -->
```ts
$.log.formatters = {
  cmd: (entry: LogEntry) => `CMD: ${entry.cmd}`,
  fetch: (entry: LogEntry) => `FETCH: ${entry.url}`
}
```

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
