### PR TITLE
feat: accept filepath as `log.output`

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -16,7 +16,7 @@
   {
     "name": "dts libdefs",
     "path": "build/*.d.ts",
-    "limit": "39.3 kB",
+    "limit": "39.4 kB",
     "brotli": false,
     "gzip": false
   },
@@ -30,7 +30,7 @@
   {
     "name": "all",
     "path": "build/*",
-    "limit": "851.1 kB",
+    "limit": "851.3 kB",
     "brotli": false,
     "gzip": false
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,10 +102,11 @@ $.log = (entry: LogEntry) => {
 ```
 
 Log mostly acts like a debugger, so by default it uses `process.error` for output.
-Set `log.output` to change the stream.
+Set `log.output` to change the stream. Setting string value will create a file stream:
 
 ```ts
 $.log.output = process.stdout
+$.log.output = 'zx.log'
 ```
 
 Set `log.formatters` to customize each log entry kind printing:

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -14,6 +14,8 @@
 
 import assert from 'node:assert'
 import { test, describe, beforeEach, before, after } from 'node:test'
+import fs from 'node:fs'
+import { tempfile } from '../src/util.ts'
 import { formatCmd, log } from '../src/log.ts'
 
 describe('log', () => {
@@ -104,6 +106,25 @@ describe('log', () => {
         verbose: true,
       })
       assert.equal(data.join(''), 'CMD: echo hi')
+      delete log.formatters
+    })
+
+    test('output as string', async () => {
+      const file = tempfile()
+
+      log.output = file
+      log({
+        kind: 'cmd',
+        cmd: 'echo hi',
+        id: '1',
+        verbose: true,
+      })
+      log.output = stream
+
+      assert.equal(
+        await fs.promises.readFile(file, 'utf-8'),
+        '$ \x1B[92mecho\x1B[39m hi\n'
+      )
     })
   })
 


### PR DESCRIPTION
<!-- It's a good idea to open an issue first for discussion. -->

continues #1123 

```ts
$.log.output = process.stdout
$.log.output = 'zx.log'
```

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
