### PR TITLE
feat: re-export `glob.globbySync` as `glob.sync`

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -16,21 +16,21 @@
   {
     "name": "dts libdefs",
     "path": "build/*.d.ts",
-    "limit": "39.3 kB",
+    "limit": "39.33 kB",
     "brotli": false,
     "gzip": false
   },
   {
     "name": "vendor",
     "path": "build/vendor-*",
-    "limit": "767.1 kB",
+    "limit": "767.12 kB",
     "brotli": false,
     "gzip": false
   },
   {
     "name": "all",
     "path": "build/*",
-    "limit": "851.1 kB",
+    "limit": "851.13 kB",
     "brotli": false,
     "gzip": false
   }

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -30,7 +30,7 @@
   {
     "name": "all",
     "path": "build/*",
-    "limit": "851.13 kB",
+    "limit": "851.14 kB",
     "brotli": false,
     "gzip": false
   }

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -16,7 +16,7 @@
   {
     "name": "dts libdefs",
     "path": "build/*.d.ts",
-    "limit": "39.33 kB",
+    "limit": "39.4 kB",
     "brotli": false,
     "gzip": false
   },
@@ -30,7 +30,7 @@
   {
     "name": "all",
     "path": "build/*",
-    "limit": "851.14 kB",
+    "limit": "851.5 kB",
     "brotli": false,
     "gzip": false
   }

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -30,7 +30,7 @@
   {
     "name": "all",
     "path": "build/*",
-    "limit": "851.5 kB",
+    "limit": "852.5 kB",
     "brotli": false,
     "gzip": false
   }

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -16,7 +16,7 @@
   {
     "name": "dts libdefs",
     "path": "build/*.d.ts",
-    "limit": "39.4 kB",
+    "limit": "39.42 kB",
     "brotli": false,
     "gzip": false
   },

--- a/docs/api.md
+++ b/docs/api.md
@@ -267,10 +267,8 @@ And it's disabled for `CI` by default.
 The [globby](https://github.com/sindresorhus/globby) package.
 
 ```js
-const packages = await glob(['package.json', 'packages/*/package.json']);
-
-// Synchronous form of glob()
-const packages = glob.sync(['package.json', 'packages/*/package.json']);
+const packages = await glob(['package.json', 'packages/*/package.json'])
+const markdowns = glob.sync('*.md') // sync API shortcut
 ```
 
 ## `which()`

--- a/docs/api.md
+++ b/docs/api.md
@@ -258,7 +258,10 @@ And it's disabled for `CI` by default.
 The [globby](https://github.com/sindresorhus/globby) package.
 
 ```js
-const packages = await glob(['package.json', 'packages/*/package.json'])
+const packages = await glob(['package.json', 'packages/*/package.json']);
+
+// Synchronous form of glob()
+const packages = glob.sync(['package.json', 'packages/*/package.json']);
 ```
 
 ## `which()`

--- a/src/vendor-extra.ts
+++ b/src/vendor-extra.ts
@@ -41,6 +41,7 @@ export const createRequire = _createRequire as unknown as (
 export const globbyModule = {
   convertPathToPattern,
   globby,
+  sync: globbySync,
   globbySync,
   globbyStream,
   generateGlobTasksSync,

--- a/test/vendor.test.js
+++ b/test/vendor.test.js
@@ -33,6 +33,7 @@ describe('vendor API', () => {
 
   test('globby() works', async () => {
     assert.deepEqual(await glob('*.md'), ['README.md'])
+    assert.deepEqual(glob.sync('*.md'), ['README.md'])
   })
 
   test('fetch() works', async () => {


### PR DESCRIPTION
<!-- It's a good idea to open an issue first for discussion. -->

Fixes #1129

<!-- Usage demo -->
```js
const packages = glob.sync(['package.json', 'packages/*/package.json']);

```

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
