### PR TITLE
feat(cli): use `ZX_`-prefixed envars as default flags

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "zx/core",
     "path": ["build/core.cjs", "build/util.cjs", "build/vendor-core.cjs"],
-    "limit": "77.6 kB",
+    "limit": "77.3 kB",
     "brotli": false,
     "gzip": false
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,7 +89,7 @@ export const argv: minimist.ParsedArgs = parseArgv(process.argv.slice(2), {
   stopEarly: true,
   parseBoolean: true,
   camelCase: true,
-})
+}, resolveDefaults({} as any, 'ZX_', process.env, new Set(['env', 'eval', 'install', 'registry'])))
 
 export async function main(): Promise<void> {
   await import('./globals.js')

--- a/src/core.ts
+++ b/src/core.ts
@@ -71,6 +71,19 @@ const EOL = Buffer.from(_EOL)
 const BR_CC = '\n'.charCodeAt(0)
 const SIGTERM = 'SIGTERM'
 const ENV_PREFIX = 'ZX_'
+const ENV_ALLOWED: Set<string> = new Set([
+  'cwd',
+  'preferLocal',
+  'detached',
+  'verbose',
+  'quiet',
+  'timeout',
+  'timeoutSignal',
+  'killSignal',
+  'prefix',
+  'postfix',
+  'shell',
+])
 const storage = new AsyncLocalStorage<Options>()
 
 function getStore() {
@@ -927,22 +940,9 @@ const promisifyStream = <S extends Writable>(
 export function resolveDefaults(
   defs: Options = defaults,
   prefix: string = ENV_PREFIX,
-  env = process.env
+  env = process.env,
+  allowed = ENV_ALLOWED
 ): Options {
-  const allowed = new Set([
-    'cwd',
-    'preferLocal',
-    'detached',
-    'verbose',
-    'quiet',
-    'timeout',
-    'timeoutSignal',
-    'killSignal',
-    'prefix',
-    'postfix',
-    'shell',
-  ])
-
   return Object.entries(env).reduce<Options>((m, [k, v]) => {
     if (v && k.startsWith(prefix)) {
       const _k = toCamelCase(k.slice(prefix.length))

--- a/src/goods.ts
+++ b/src/goods.ts
@@ -38,7 +38,8 @@ type ArgvOpts = minimist.Opts & { camelCase?: boolean; parseBoolean?: boolean }
 
 export const parseArgv = (
   args: string[] = process.argv.slice(2),
-  opts: ArgvOpts = {}
+  opts: ArgvOpts = {},
+  defs: Record<string, any> = {}
 ): minimist.ParsedArgs =>
   Object.entries(minimist(args, opts)).reduce<minimist.ParsedArgs>(
     (m, [k, v]) => {
@@ -48,7 +49,7 @@ export const parseArgv = (
       m[_k] = _v
       return m
     },
-    {} as minimist.ParsedArgs
+    { ...defs } as minimist.ParsedArgs
   )
 
 export function updateArgv(args?: string[], opts?: ArgvOpts) {

--- a/test/goods.test.js
+++ b/test/goods.test.js
@@ -156,6 +156,9 @@ describe('goods', () => {
           camelCase: true,
           parseBoolean: true,
           alias: { a: 'aaa' },
+        },
+        {
+          def: 'def',
         }
       ),
       {
@@ -170,6 +173,7 @@ describe('goods', () => {
         b4: false,
         b5: true,
         b6: true,
+        def: 'def',
       }
     )
   })


### PR DESCRIPTION
Restore CLI flags ~ envars symmetry.
```js
ZX_REGISTRY='https://custom-registry.example.com' zx script.js
```

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
