### PR TITLE
fix: Avoid using default import of node:path

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -64,7 +64,7 @@ import {
 
 import { log } from './log.ts'
 
-export { default as path } from 'node:path'
+export * as path from 'node:path'
 export * as os from 'node:os'
 import { Buffer } from 'node:buffer'
 import process from 'node:process'


### PR DESCRIPTION
Fixed the method of importing node:path.
Before the fix, if `allowSyntheticDefaultImports` was set to false in tsconfig, `path` would be of type `any`.


- [x] Tests pass
- [x] Appropriate changes to README are included in PR
