### PR TITLE
fix: handle `.nothrow()` option in `ProcessProcess[AsyncIterator]`

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -45,7 +45,7 @@
   {
     "name": "all",
     "path": ["build/*", "man/*", "README.md", "LICENSE"],
-    "limit": "872.6 kB",
+    "limit": "872.65 kB",
     "brotli": false,
     "gzip": false
   }

--- a/build/core.cjs
+++ b/build/core.cjs
@@ -806,6 +806,7 @@ var _ProcessPromise = class _ProcessPromise extends Promise {
         }
       }
       if (memo[0]) yield memo[0];
+      if (this.isNothrow()) return;
       if ((yield new __await(this.exitCode)) !== 0) throw this._output;
     });
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -647,6 +647,8 @@ export class ProcessPromise extends Promise<ProcessOutput> {
 
     if (memo[0]) yield memo[0]
 
+    if (this.isNothrow()) return
+
     if ((await this.exitCode) !== 0) throw this._output
   }
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1048,6 +1048,14 @@ describe('core', () => {
           'The process exit code should be 1'
         )
       })
+
+      it('handles .nothrow() correctly', async () => {
+        const data = []
+        for await (const line of $({ nothrow: true })`grep any test`) {
+          data.push(line)
+        }
+        assert.equal(data.length, 0, 'Should not yield any lines')
+      })
     })
 
     test('quiet() mode is working', async () => {
@@ -1083,8 +1091,10 @@ describe('core', () => {
     })
 
     test('nothrow() does not throw', async () => {
-      const { exitCode } = await $`exit 42`.nothrow()
-      assert.equal(exitCode, 42)
+      {
+        const { exitCode } = await $`exit 42`.nothrow()
+        assert.equal(exitCode, 42)
+      }
       {
         // Toggle
         try {


### PR DESCRIPTION
closes #1216

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
