### PR TITLE
refactor: set `SIGTERM` as `kill()` fallback signal

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -15,7 +15,7 @@
       "README.md",
       "LICENSE"
     ],
-    "limit": "124.90 kB",
+    "limit": "125.00 kB",
     "brotli": false,
     "gzip": false
   },
@@ -29,7 +29,7 @@
       "build/globals.js",
       "build/deno.js"
     ],
-    "limit": "815.00 kB",
+    "limit": "815.10 kB",
     "brotli": false,
     "gzip": false
   },
@@ -62,7 +62,7 @@
       "README.md",
       "LICENSE"
     ],
-    "limit": "872.40 kB",
+    "limit": "872.45 kB",
     "brotli": false,
     "gzip": false
   }

--- a/build/core.cjs
+++ b/build/core.cjs
@@ -1115,7 +1115,8 @@ function cd(dir) {
   $[CWD] = import_node_process2.default.cwd();
 }
 function kill(_0) {
-  return __async(this, arguments, function* (pid, signal = $.killSignal) {
+  return __async(this, arguments, function* (pid, signal = $.killSignal || SIGTERM) {
+    $.log({ kind: "kill", pid, signal, verbose: !$.quiet && $.verbose });
     if (import_node_process2.default.platform === "win32" && (yield new Promise((resolve) => {
       import_node_child_process.default.exec(`taskkill /pid ${pid} /t /f`, (err) => resolve(!err));
     })))

--- a/build/core.d.ts
+++ b/build/core.d.ts
@@ -207,5 +207,5 @@ export declare function usePwsh(): void;
 export declare function useBash(): void;
 export declare function syncProcessCwd(flag?: boolean): void;
 export declare function cd(dir: string | ProcessOutput): void;
-export declare function kill(pid: number, signal?: NodeJS.Signals | undefined): Promise<void>;
+export declare function kill(pid: number, signal?: NodeJS.Signals): Promise<void>;
 export declare function resolveDefaults(defs?: Options, prefix?: string, env?: NodeJS.ProcessEnv, allowed?: Set<string>): Options;

--- a/src/core.ts
+++ b/src/core.ts
@@ -1050,7 +1050,8 @@ export function cd(dir: string | ProcessOutput) {
   $[CWD] = process.cwd()
 }
 
-export async function kill(pid: number, signal = $.killSignal) {
+export async function kill(pid: number, signal = $.killSignal || SIGTERM) {
+  $.log({ kind: 'kill', pid, signal, verbose: !$.quiet && $.verbose })
   if (
     process.platform === 'win32' &&
     (await new Promise((resolve) => {


### PR DESCRIPTION
continues #1312 

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
