### PR TITLE
ci: separate next version resolver to sub job

### DIFF
--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       v: ${{ steps.ref.outputs.ZX_VERSION }}
-      lite: ${{ steps.dev.outputs.ZX_VERSION }}-lite
+      lite: ${{ steps.ref.outputs.ZX_VERSION }}-lite
       dev: ${{ steps.ref.outputs.ZX_VERSION }}-dev.${{ steps.ref.outputs.SHA_SHORT }}
       lite-dev: ${{ steps.ref.outputs.ZX_VERSION }}-lite-dev.${{ steps.ref.outputs.SHA_SHORT }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       v: ${{ steps.ref.outputs.ZX_VERSION }}
-      lite: ${{ steps.dev.outputs.ZX_VERSION }}-lite
+      lite: ${{ steps.ref.outputs.ZX_VERSION }}-lite
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
continues #1320 

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
