### PR TITLE
chore(deps): add semver dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "zx",
       "version": "8.8.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "semver": "^7.7.2"
+      },
       "bin": {
         "zx": "build/cli.js"
       },
@@ -6900,7 +6903,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -206,5 +206,8 @@
     "compilerOptions": {
       "rootDir": "."
     }
+  },
+  "dependencies": {
+    "semver": "^7.7.2"
   }
 }


### PR DESCRIPTION
Closes #1085

Added semver to dependencies for reliable semantic-version parsing/comparison.

Usage:
```bash

import semver from 'semver';
console.log(semver.gt('1.3.0', '1.2.3')); // true

```

- [ ] package-lock updated
- [ ] tests passed locally
