### PR TITLE
feat: update `ps` utils to support Windows kernel >= 26000

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,10 @@ jobs:
           npm run test:dcr
 
   smoke-win32-node16:
-    runs-on: windows-2022
+    strategy:
+      matrix:
+        os: [windows-2022, windows-2025]
+    runs-on: ${{ matrix.os }}
     needs: build
     steps:
       - uses: actions/checkout@v5

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -19,7 +19,7 @@
       "README.md",
       "LICENSE"
     ],
-    "limit": "128.30 kB",
+    "limit": "128.85 kB",
     "brotli": false,
     "gzip": false
   },
@@ -33,7 +33,7 @@
       "build/globals.js",
       "build/deno.js"
     ],
-    "limit": "816.10 kB",
+    "limit": "816.65 kB",
     "brotli": false,
     "gzip": false
   },
@@ -47,7 +47,7 @@
   {
     "name": "vendor",
     "path": "build/vendor-*.{cjs,d.ts}",
-    "limit": "767.20 kB",
+    "limit": "767.75 kB",
     "brotli": false,
     "gzip": false
   },
@@ -66,7 +66,7 @@
       "README.md",
       "LICENSE"
     ],
-    "limit": "873.65 kB",
+    "limit": "874.15 kB",
     "brotli": false,
     "gzip": false
   }

--- a/build/3rd-party-licenses
+++ b/build/3rd-party-licenses
@@ -20,7 +20,7 @@ THIRD PARTY LICENSES
   sindresorhus/merge-streams
   MIT
 
-@webpod/ps@0.1.4
+@webpod/ps@1.0.0
   <unknown>
   git://github.com/webpod/ps.git
   MIT

--- a/build/index.cjs
+++ b/build/index.cjs
@@ -62,7 +62,7 @@ var versions = {
   fs: "11.3.2",
   glob: "14.1.0",
   minimist: "1.2.8",
-  ps: "0.1.4",
+  ps: "1.0.0",
   which: "5.0.0",
   yaml: "2.8.1"
 };

--- a/build/vendor-core.d.ts
+++ b/build/vendor-core.d.ts
@@ -224,7 +224,6 @@ type TPsLookupQuery = {
 	command?: string;
 	arguments?: string;
 	ppid?: number | string;
-	psargs?: string | string[];
 };
 type TPsKillOptions = {
 	timeout?: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/node": "24.5.2",
         "@types/which": "3.0.4",
         "@webpod/ingrid": "1.1.1",
-        "@webpod/ps": "0.1.4",
+        "@webpod/ps": "1.0.0",
         "c8": "10.1.3",
         "chalk": "5.6.2",
         "create-require": "1.1.1",
@@ -2475,14 +2475,14 @@
       "license": "MIT"
     },
     "node_modules/@webpod/ps": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@webpod/ps/-/ps-0.1.4.tgz",
-      "integrity": "sha512-Mq62ZvqAD2uF+b+MjGua7K1lkARk6vzYJTfZDe6h8lYbIXYticPpP+FWA3SPzjKlQQl7EJRdcoB4Xst3IOKz4g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@webpod/ps/-/ps-1.0.0.tgz",
+      "integrity": "sha512-jF9WpjVPsCUO4GnoCo5ngbV7szcYwZ+SzgcHtIXOJokx9SBJt8ADXtsgpnnB/UjBZTXUNPb8aXnCcJrv2TxGWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webpod/ingrid": "^1.1.1",
-        "zurk": "^0.11.4"
+        "zurk": "^0.11.5"
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@types/node": "24.5.2",
     "@types/which": "3.0.4",
     "@webpod/ingrid": "1.1.1",
-    "@webpod/ps": "0.1.4",
+    "@webpod/ps": "1.0.0",
     "c8": "10.1.3",
     "chalk": "5.6.2",
     "create-require": "1.1.1",

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -21,7 +21,7 @@ export const versions: Record<string, string> = {
   fs: '11.3.2',
   glob: '14.1.0',
   minimist: '1.2.8',
-  ps: '0.1.4',
+  ps: '1.0.0',
   which: '5.0.0',
   yaml: '2.8.1',
 }


### PR DESCRIPTION
```
WMIC will be missing in Windows 11 25H2 (kernel >= 26000)
```

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
