### PR TITLE
build: remove redundant await from `readFileSync` calls

### DIFF
--- a/scripts/build-tests.mjs
+++ b/scripts/build-tests.mjs
@@ -29,7 +29,7 @@ const modules = [
 const root = path.resolve(new URL(import.meta.url).pathname, '../..')
 const filePath = path.resolve(root, `test/export.test.js`)
 
-const copyright = await fs.readFileSync(
+const copyright = fs.readFileSync(
   path.resolve(root, 'test/fixtures/copyright.txt'),
   'utf8'
 )

--- a/scripts/build-versions.mjs
+++ b/scripts/build-versions.mjs
@@ -19,7 +19,7 @@ import path from 'node:path'
 import minimist from 'minimist'
 
 const root = path.resolve(new URL(import.meta.url).pathname, '../..')
-const copyright = await fs.readFileSync(
+const copyright = fs.readFileSync(
   path.resolve(root, 'test/fixtures/copyright.txt'),
   'utf8'
 )


### PR DESCRIPTION
Remove incorrect await keyword from fs.readFileSync() calls in build-versions.mjs and build-tests.mjs. readFileSync is synchronous and doesn't return a Promise, so await is invalid syntax.
