### PR TITLE
fix: throw clear error when cwd directory does not exist

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -19,7 +19,7 @@
       "README.md",
       "LICENSE"
     ],
-    "limit": "129.25 kB",
+    "limit": "129.60 kB",
     "brotli": false,
     "gzip": false
   },
@@ -33,7 +33,7 @@
       "build/globals.js",
       "build/deno.js"
     ],
-    "limit": "847.80 kB",
+    "limit": "848.15 kB",
     "brotli": false,
     "gzip": false
   },
@@ -66,7 +66,7 @@
       "README.md",
       "LICENSE"
     ],
-    "limit": "909.40 kB",
+    "limit": "909.75 kB",
     "brotli": false,
     "gzip": false
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -289,6 +289,16 @@ export class ProcessPromise extends Promise<ProcessOutput> {
       throw new Fail(`No quote function is defined: ${Fail.DOCS_URL}/quotes`)
     if ($.pieces.some((p) => p == null))
       throw new Fail(`Malformed command at ${$.from}`)
+    if ($.cwd) {
+      try {
+        const stat = fs.statSync($.cwd)
+        if (!stat.isDirectory())
+          throw new Fail(`The cwd option is not a directory: ${$.cwd}`)
+      } catch (err) {
+        if (err instanceof Fail) throw err
+        throw new Fail(`The cwd directory does not exist: ${$.cwd}`)
+      }
+    }
 
     $.cmd = buildCmd(
       $.quote!,

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -256,15 +256,28 @@ describe('core', () => {
       assert.match(err[inspect.custom](), /Command not found/)
     })
 
-    test('error event is handled', async () => {
+    test('error is thrown for non-existent cwd', async () => {
       await within(async () => {
         $.cwd = 'wtf'
         try {
           await $`pwd`
           assert.unreachable('should have thrown')
         } catch (err) {
-          assert.ok(err instanceof ProcessOutput)
-          assert.match(err.message, /No such file or directory/)
+          assert.ok(err instanceof Fail)
+          assert.match(err.message, /The cwd directory does not exist: wtf/)
+        }
+      })
+    })
+
+    test('error is thrown when cwd is a file', async () => {
+      await within(async () => {
+        $.cwd = './README.md'
+        try {
+          await $`pwd`
+          assert.unreachable('should have thrown')
+        } catch (err) {
+          assert.ok(err instanceof Fail)
+          assert.match(err.message, /The cwd option is not a directory/)
         }
       })
     })


### PR DESCRIPTION
 fix: throw clear error when cwd directory does not exist                  
                                                        
  ## Summary                                                                
  - Adds early validation for the `cwd` option before executing commands    
  - Throws a clear `Fail` error if the directory doesn't exist or isn't a   
  directory                                                                 
  - Improves DX by providing actionable error messages instead of cryptic   
  spawn errors                                                              
                                                                            
  **Before:** Users got cryptic errors like "Top-level await promise never  
  resolved"                                                                 
  **After:** Users get clear messages like `The cwd directory does not      
  exist: /path/to/dir`                                                      
                                                                            
  ## Test plan                                                              
  - [x] Added test for non-existent cwd directory                           
  - [x] Added test for cwd pointing to a file instead of directory          
  - [x] Verified existing functionality still works                         
  - [x] Updated size limits to accommodate the ~320 byte increase           
                                                                            
  Fixes #1386                                                               
                        
