### PR TITLE
fix(cli): prevent double extension in temp file for stdin markdown with --ext

### DIFF
--- a/build/cli.cjs
+++ b/build/cli.cjs
@@ -304,7 +304,7 @@ function readScript() {
     }
     if (ext === ".md") {
       script = transformMarkdown(script);
-      tempPath = getFilepath(dir, base);
+      tempPath = getFilepath(dir, base, EXT);
     }
     if (argSlice) (0, import_index.updateArgv)(argv._.slice(argSlice));
     return { script, scriptPath, tempPath };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -232,7 +232,7 @@ async function readScript() {
   }
   if (ext === '.md') {
     script = transformMarkdown(script)
-    tempPath = getFilepath(dir, base)
+    tempPath = getFilepath(dir, base, EXT)
   }
   if (argSlice) updateArgv(argv._.slice(argSlice))
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -347,6 +347,12 @@ console.log(a);
     assert.ok(p.stdout.includes('Hello, world!'))
   })
 
+  test('markdown scripts from stdin with --ext .md', async () => {
+    const md = '# Test\n\n```js\necho("md-stdin-ok")\n```\n'
+    const p = await $`node build/cli.js --ext='.md' <<< ${md}`
+    assert.match(p.stdout, /md-stdin-ok/)
+  })
+
   test('exceptions are caught', async () => {
     const out1 = await $`node build/cli.js <<<${'await $`wtf`'}`.nothrow()
     const out2 = await $`node build/cli.js <<<'throw 42'`.nothrow()


### PR DESCRIPTION
Fixes the issue where `echo '...' | npx zx --ext='.md'` produces a temp file named `zx.md.md`, causing Node.js to fail with `ERR_UNKNOWN_FILE_EXTENSION`.

After `transformMarkdown()` converts markdown to JavaScript, the temp file should use `.mjs`. However, `getFilepath(dir, base)` fell back to `argv.ext` (`.md`), resulting in a double extension. This fix explicitly passes `EXT` (`.mjs`) to prevent the fallback.

#### Before

```bash
$ printf '# Test\n\n```js\necho("hello from markdown")\n```\n' | npx zx --verbose --ext='.md'
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".md" for /Users/gin0606/zx.md.md
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:185:9)
    at defaultGetFormat (node:internal/modules/esm/get_format:211:36)
    at defaultLoadSync (node:internal/modules/esm/load:158:16)
    at #loadAndMaybeBlockOnLoaderThread (node:internal/modules/esm/loader:795:12)
    at #loadSync (node:internal/modules/esm/loader:815:49)
    at ModuleLoader.load (node:internal/modules/esm/loader:780:26)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:526:31)
    at #getOrCreateModuleJobAfterResolve (node:internal/modules/esm/loader:571:36)
    at afterResolve (node:internal/modules/esm/loader:624:52)
    at ModuleLoader.getOrCreateModuleJob (node:internal/modules/esm/loader:630:12) {
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
}
```

#### After
```bash
$ printf '# Test\n\n```js\necho("hello from markdown")\n```\n' | node build/cli.js --verbose --ext='.md'
hello from markdown
```

----

- [x] **Build**: I’ve run `npm build` before committing and verified the bundle updates correctly.
- [x] **Tests**: I’ve `run test` and confirmed all tests succeed.
- [x] **Docs**: I’ve added or updated relevant documentation as needed.
- [x] **Sign** Commits have [verified signatures](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/about-commit-signature-verification) and follow [conventinal commits spec](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] **CoC**: My changes follow [the project’s coding guidelines and Code of Conduct](https://github.com/google/zx?tab=coc-ov-file).  
- [x] **Review**: This PR represents original work and is not solely generated by AI tools.
