### PR TITLE
fix: properly escape single quotes in versions script

### DIFF
--- a/scripts/build-versions.mjs
+++ b/scripts/build-versions.mjs
@@ -63,6 +63,7 @@ const argv = minimist(process.argv.slice(2), {
 delete argv._
 
 const list = JSON.stringify(argv, null, 2)
+  .replaceAll("'", "\\'")
   .replaceAll('  "', '  ')
   .replaceAll('": ', ': ')
   .replaceAll('"', "'")


### PR DESCRIPTION
When serializing `argv` into `src/versions.ts` using `JSON.stringify()`, single quotes weren't properly escaped before replacing the outer double quotes with single quotes. This could lead to malformed syntax in the generated file if an argument value contained a single quote. 

Added `.replaceAll("'", "\\'")` to ensure safe string literal generation.