### PR TITLE
fix: handle ps.tree() failure gracefully in kill() on Alpine Linux

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1085,10 +1085,9 @@ export async function kill(
         process.kill(+p.pid, signal)
       } catch (e) {}
     }
-  } catch (e) {
-    // ps.tree() can fail on non-standard ps implementations (e.g. BusyBox on
-    // Alpine Linux) that produce output the parser cannot handle. Fall through
-    // to the direct process.kill() below so the parent process is still killed.
+  } catch {
+    // getBorders() in @webpod/ingrid crashes on empty ps output (e.g. BusyBox).
+    // Fall through to kill the main process directly below.
   }
   try {
     process.kill(-pid, signal)

--- a/src/core.ts
+++ b/src/core.ts
@@ -1079,10 +1079,16 @@ export async function kill(
   )
     return
 
-  for (const p of await ps.tree({ pid, recursive: true })) {
-    try {
-      process.kill(+p.pid, signal)
-    } catch (e) {}
+  try {
+    for (const p of await ps.tree({ pid, recursive: true })) {
+      try {
+        process.kill(+p.pid, signal)
+      } catch (e) {}
+    }
+  } catch (e) {
+    // ps.tree() can fail on non-standard ps implementations (e.g. BusyBox on
+    // Alpine Linux) that produce output the parser cannot handle. Fall through
+    // to the direct process.kill() below so the parent process is still killed.
   }
   try {
     process.kill(-pid, signal)


### PR DESCRIPTION
## Problem

On Alpine Linux (and other environments using BusyBox), `kill()` throws an unexpected `TypeError` instead of killing the process:

```
TypeError: Cannot read properties of undefined (reading 'spaces')
    at getBorders (vendor-core.cjs)
    at parseUnixGrid (vendor-core.cjs)
```

This was introduced in v8.8.4 when `@webpod/ps` replaced the previous process tree implementation. BusyBox `ps` produces output in a format that `@webpod/ingrid` cannot parse — it returns an empty array, causing `lines[0].spaces` to throw.

Reported in #1369.

## Fix

Wrap the `ps.tree()` loop in a try/catch in `src/core.ts`. If the process tree lookup fails (e.g. due to an unrecognised `ps` output format), execution falls through to the existing `process.kill(pid)` call below, which still terminates the target process. Child processes may not be killed in degraded environments, but the caller no longer receives an unexpected error.

```ts
// Before
for (const p of await ps.tree({ pid, recursive: true })) {
  try { process.kill(+p.pid, signal) } catch (e) {}
}

// After
try {
  for (const p of await ps.tree({ pid, recursive: true })) {
    try { process.kill(+p.pid, signal) } catch (e) {}
  }
} catch (e) {
  // ps.tree() can fail on non-standard ps implementations (e.g. BusyBox on
  // Alpine Linux). Fall through to direct process.kill() below.
}
```

The root cause is in `@webpod/ingrid`'s parser — a fix there would be more complete — but this makes `kill()` robust against any future parser failures as well.