### PR TITLE
fix(core): prevent command injection by removing unsafe cmd.exe fallback on Windows

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1022,13 +1022,40 @@ function setShell(n: string, ps = true) {
   $.quote = ps ? quotePowerShell : quote
 }
 
-try {
+{
+  // Preserve any shell/prefix/postfix overrides the caller may have set
+  // before we attempt shell detection (set -euo pipefail etc.).
   const { shell, prefix, postfix } = $
-  useBash()
-  if (isString(shell)) $.shell = shell
-  if (isString(prefix)) $.prefix = prefix
+  try {
+    useBash()
+  } catch {
+    // bash not found — on Windows we must NOT fall through to cmd.exe: its
+    // parser does not honour bash-style $'…' quoting, so every interpolated
+    // argument is a potential command-injection vector.
+    if (process.platform === 'win32') {
+      const winShell = which.sync('pwsh', { nothrow: true })
+        ?? which.sync('powershell.exe', { nothrow: true })
+      if (!winShell) {
+        throw new Fail(
+          `No safe shell found: 'bash', 'pwsh', and 'powershell.exe' are all absent from PATH. ` +
+          `Running under cmd.exe is unsafe because bash-style quoting does not apply there.`
+        )
+      }
+      // pwsh / powershell.exe — use the PowerShell quoting convention and
+      // the standard ; exit $LastExitCode postfix.
+      $.shell  = winShell
+      $.prefix = ''
+      $.postfix = '; exit $LastExitCode'
+      $.quote  = quotePowerShell
+    }
+    // On non-Windows platforms the original behaviour (shell:true via
+    // execvp) is acceptable; no action needed.
+  }
+  // Re-apply explicit caller overrides now that defaults are set.
+  if (isString(shell))   $.shell   = shell
+  if (isString(prefix))  $.prefix  = prefix
   if (isString(postfix)) $.postfix = postfix
-} catch (err) {}
+}
 
 let cwdSyncHook: AsyncHook
 


### PR DESCRIPTION
Reported-by: LAKSHMIKANTHAN K (letchupkt)
CWE: CWE-78 (Command Injection)


Fixes #issue / suggests an improvement

## Summary

This PR fixes a command injection vulnerability on Windows caused by an unsafe fallback to `cmd.exe` when `bash` is unavailable.

Previously, if `useBash()` failed, the error was silently ignored and execution continued with Node’s default `shell: true`, which resolves to `cmd.exe` on Windows. However, `zx` continued using Bash-style quoting (`$'...'`), which is not supported by `cmd.exe`, allowing special characters (e.g., `&`) to break out of argument boundaries and execute arbitrary commands.

This change ensures that `zx` never falls back to `cmd.exe` in an unsafe configuration.

## Relevant technical choices

* Added explicit Windows-specific fallback handling when `bash` is unavailable
* Introduced safe shell resolution:

  * Prefer `pwsh`
  * Fallback to `powershell.exe`
* If no safe shell is available, throw a `Fail` error instead of falling back to `cmd.exe`
* Updated quoting behavior to use `quotePowerShell` for PowerShell-based shells
* Preserved original behavior for non-Windows environments

The fix ensures that command execution always uses a shell compatible with the quoting mechanism, preventing injection vulnerabilities 

## Impact

Prevents command injection on Windows systems where `bash` is not installed.

This mitigates:

* Arbitrary command execution via interpolated variables
* Silent bypass of zx’s escaping guarantees
* Execution of unintended commands due to shell mismatch 

## Usage demo

```ts id="safezx"
import {$} from 'zx'
```

* [x] **Setup** Set the latest Node.js LTS version.
* [x] **Build**: I’ve run `npm build` before committing and verified the bundle updates correctly.
* [x] **Tests**: I’ve `run test` and confirmed all tests succeed. Added tests to cover my changes if needed.
* [x] **Docs**: I’ve added or updated relevant documentation as needed.
* [x] **Sign** Commits have verified signatures and follow conventional commits spec
* [x] **CoC**: My changes follow the project’s coding guidelines and Code of Conduct.
* [x] **Review**: This PR represents original work and is not solely generated by AI tools.

