### PR TITLE
fix: handle stream read errors in responseToReadable

### DIFF
--- a/src/goods.ts
+++ b/src/goods.ts
@@ -111,8 +111,12 @@ const responseToReadable = (response: Response, rs: Readable) => {
     return rs
   }
   rs._read = async () => {
-    const result = await reader.read()
-    rs.push(result.done ? null : Buffer.from(result.value))
+    try {
+      const result = await reader.read()
+      rs.push(result.done ? null : Buffer.from(result.value))
+    } catch (err) {
+      rs.destroy(err instanceof Error ? err : new Error(String(err)))
+    }
   }
   return rs
 }


### PR DESCRIPTION
Fixes #1443

The `responseToReadable` function in `src/goods.ts` assigns an async function to `rs._read` without error handling. If `reader.read()` throws (e.g. network disconnection, aborted request, corrupted stream), the promise rejection is unhandled and crashes the Node.js process.

## Fix

Wrapped the async `_read` body in try/catch. Errors are propagated to the stream via `rs.destroy(err)`, allowing downstream consumers to handle them gracefully instead of crashing.

## Usage demo

```ts
import { fetch } from 'zx'

const controller = new AbortController()
const result = fetch('https://speed.hetzner.de/100MB.bin', { signal: controller.signal })
const p = result.pipe`cat`
setTimeout(() => controller.abort(), 100)
// Before: UnhandledPromiseRejection crashes process
// After: Error propagated through stream, handled gracefully
```

- [x] **Setup** Set the latest Node.js LTS version.
- [x] **Build**: I've run `npm build` before committing and verified the bundle updates correctly.
- [x] **Tests**: I've `run test` and confirmed all tests succeed. Added tests to cover my changes if needed.
- [x] **Docs**: I've added or updated relevant documentation as needed.
- [x] **Sign** Commits have [verified signatures](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/about-commit-signature-verification) and follow [conventinal commits spec](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] **CoC**: My changes follow [the project's coding guidelines and Code of Conduct](https://github.com/google/zx?tab=coc-ov-file).
- [ ] **Review**: This PR represents original work and is not solely generated by AI tools.