### PR TITLE
docs: add security warning for ZX_PREFIX and ZX_POSTFIX env variables

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -177,6 +177,10 @@ steps:
       ZX_VERBOSE: true
       ZX_SHELL: '/bin/bash'
 ```
+> [!WARNING]
+> **Security Note:** Environment variables like `ZX_PREFIX`, `ZX_POSTFIX`, and `ZX_SHELL` are injected globally into *every* command executed via the `$` template tag without sanitization. If you are using `zx` in shared environments or CI/CD pipelines, be aware that untrusted parties who can set environment variables can implicitly execute arbitrary shell commands.
+
+
 
 ## `__filename & __dirname`
 


### PR DESCRIPTION
Resolves #1435 

### What does this PR do?
This PR adds a security warning to the documentation regarding the use of `ZX_PREFIX`, `ZX_POSTFIX`, and `ZX_SHELL` environment variables. 

As highlighted in issue #1435, because these variables are injected globally into every command executed via the `$` template tag without sanitization, they represent a potential silent command injection surface. While this behavior is highly useful for parameterization in CI/CD and containerized environments, it wasn't explicitly documented as a security boundary.

### Changes made:
* Added a `> [!WARNING]` callout in `docs/cli.md` under the **Environment variables** section.
* Added a `> [!WARNING]` callout in `docs/configuration.md` under the **`$.prefix`** section.

These notes ensure developers are explicitly aware of the risks when using untrusted environment variables in shared or automated environments.