### PR TITLE
fix: catch errors in responseToReadable _read callback

### DIFF
--- a/src/goods.ts
+++ b/src/goods.ts
@@ -111,8 +111,12 @@ const responseToReadable = (response: Response, rs: Readable) => {
     return rs
   }
   rs._read = async () => {
-    const result = await reader.read()
-    rs.push(result.done ? null : Buffer.from(result.value))
+    try {
+      const result = await reader.read()
+      rs.push(result.done ? null : Buffer.from(result.value))
+    } catch (err) {
+      rs.destroy(err as Error)
+    }
   }
   return rs
 }


### PR DESCRIPTION
Fixes #1443. The async _read callback in responseToReadable did not wrap reader.read() in a try/catch. If the reader throws (network error, abort, corrupted stream), the rejection was unhandled and could crash the process. Now caught and propagated via rs.destroy(err).