### PR TITLE
fix: defer cmd log to respect .quiet()/.verbose() overrides

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -19,7 +19,7 @@
       "README.md",
       "LICENSE"
     ],
-    "limit": "129.42 kB",
+    "limit": "130 kB",
     "brotli": false,
     "gzip": false
   },
@@ -33,7 +33,7 @@
       "build/globals.js",
       "build/deno.js"
     ],
-    "limit": "858.98 kB",
+    "limit": "860 kB",
     "brotli": false,
     "gzip": false
   },
@@ -66,7 +66,7 @@
       "README.md",
       "LICENSE"
     ],
-    "limit": "920.71 kB",
+    "limit": "922 kB",
     "brotli": false,
     "gzip": false
   }

--- a/build/core.cjs
+++ b/build/core.cjs
@@ -583,7 +583,8 @@ var _ProcessPromise = class _ProcessPromise extends Promise {
       },
       on: {
         start: () => {
-          $2.log({ kind: "cmd", cmd: $2.cmd, cwd, verbose: self.isVerbose(), id });
+          const cmdOpts = { kind: "cmd", cmd: $2.cmd, cwd, id };
+          queueMicrotask(() => $2.log(__spreadProps(__spreadValues({}, cmdOpts), { verbose: self.isVerbose() })));
           self.timeout($2.timeout, $2.timeoutSignal);
         },
         stdout: (data) => {

--- a/src/core.ts
+++ b/src/core.ts
@@ -360,7 +360,8 @@ export class ProcessPromise extends Promise<ProcessOutput> {
       },
       on: {
         start: () => {
-          $.log({ kind: 'cmd', cmd: $.cmd, cwd, verbose: self.isVerbose(), id })
+          const cmdOpts = { kind: 'cmd' as const, cmd: $.cmd, cwd, id }
+          queueMicrotask(() => $.log({ ...cmdOpts, verbose: self.isVerbose() }))
           self.timeout($.timeout, $.timeoutSignal)
         },
         stdout: (data) => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1363,6 +1363,71 @@ describe('core', () => {
       assert.equal(p.isVerbose(), false)
     })
 
+    test('quiet() suppresses cmd log entry (#931)', async () => {
+      const logs = []
+      const origLog = $.log
+      $.log = (entry) => {
+        logs.push(entry)
+        origLog(entry)
+      }
+      $.verbose = true
+      $.quiet = false
+
+      await $`echo "hello"`.quiet()
+      const cmdEntry = logs.find((l) => l.kind === 'cmd')
+      $.log = origLog
+      assert.equal(cmdEntry.verbose, false)
+    })
+
+    test('verbose(false) suppresses cmd log entry (#931)', async () => {
+      const logs = []
+      const origLog = $.log
+      $.log = (entry) => {
+        logs.push(entry)
+        origLog(entry)
+      }
+      $.verbose = true
+      $.quiet = false
+
+      await $`echo "hello"`.verbose(false)
+      const cmdEntry = logs.find((l) => l.kind === 'cmd')
+      $.log = origLog
+      assert.equal(cmdEntry.verbose, false)
+    })
+
+    test('quiet(false) enables cmd log when $.quiet=true (#931)', async () => {
+      const logs = []
+      const origLog = $.log
+      $.log = (entry) => {
+        logs.push(entry)
+        origLog(entry)
+      }
+      $.verbose = true
+      $.quiet = true
+
+      await $`echo "hello"`.quiet(false)
+      const cmdEntry = logs.find((l) => l.kind === 'cmd')
+      $.log = origLog
+      $.quiet = false
+      assert.equal(cmdEntry.verbose, true)
+    })
+
+    test('verbose(true) enables cmd log when $.verbose=false (#931)', async () => {
+      const logs = []
+      const origLog = $.log
+      $.log = (entry) => {
+        logs.push(entry)
+        origLog(entry)
+      }
+      $.verbose = false
+      $.quiet = false
+
+      await $`echo "hello"`.verbose(true)
+      const cmdEntry = logs.find((l) => l.kind === 'cmd')
+      $.log = origLog
+      assert.equal(cmdEntry.verbose, true)
+    })
+
     test('nothrow() does not throw', async () => {
       {
         const { exitCode } = await $`exit 42`.nothrow()


### PR DESCRIPTION
## Summary

- Fixes #931
- Defers the `cmd` log entry in `ProcessPromise.run()` with `queueMicrotask()` so that chained `.quiet()` / `.verbose()` overrides take effect before the log is emitted

## Problem

Since PR #914 removed the `setImmediate` around `run()`, the `start` event fires synchronously during `run()`, which is called before chained methods like `.quiet()` or `.verbose()` can modify the snapshot. This means the `cmd` log entry always uses the original verbose/quiet state, ignoring per-call overrides.

Observed behavior:
- `.quiet()` does not suppress the command line output
- `.verbose(false)` does not suppress the command line output
- `.quiet(false)` does not enable the command line output when `$.quiet = true`
- `.verbose(true)` does not enable the command line output when `$.verbose = false`

## Fix

Instead of reverting the `setImmediate` removal (which was needed for pipe splitting), this PR defers only the `cmd` log entry using `queueMicrotask()`. This is more targeted:

- The process still starts synchronously (no change to spawn timing)
- `queueMicrotask` runs after the current synchronous call stack completes but before any I/O, so chained methods have already executed
- The timeout setup remains synchronous for correct timing

## Test plan

- [x] Added 4 new test cases covering all `.quiet()`/`.verbose()` override scenarios from #931
- [x] All 264 existing passing tests continue to pass (6 pre-existing failures unrelated to this change)

