### PR TITLE
fix(md): escape template literal metacharacters in bash fence blocks

### DIFF
--- a/src/md.ts
+++ b/src/md.ts
@@ -88,7 +88,13 @@ export function transformMarkdown(buf: Buffer | string): string {
           prevEmpty = true
           fenceChar = ''
         } else {
-          const s = stripRe ? line.replace(stripRe, '') : line
+          let s = stripRe ? line.replace(stripRe, '') : line
+          if (closeOut === '`') {
+            s = s
+              .replace(/\\/g, '\\\\')
+              .replace(/`/g, '\\`')
+              .replace(/\${/g, '\\${')
+          }
           out.push(linePrefix + s)
           prevEmpty = false
         }

--- a/test/md.test.ts
+++ b/test/md.test.ts
@@ -122,4 +122,42 @@ echo "4"
     const expected = '// a\n// b\n// c\n// d\n// e\n// f'
     assert.equal(transformMarkdown(input), expected)
   })
+
+  describe('security: bash fence injection prevention', () => {
+    test('escapes ${...} interpolation in bash fences to prevent JS injection', () => {
+      const result = transformMarkdown(
+        '```bash\necho ${require("child_process").execSync("id")}\n```'
+      )
+      assert.ok(
+        result.includes('\\${require'),
+        'interpolation not escaped in bash fence output'
+      )
+    })
+
+    test('escapes backticks in bash fences to prevent template literal breakout', () => {
+      const result = transformMarkdown('```bash\necho `uname -s`\n```')
+      assert.ok(
+        result.includes('\\`uname'),
+        'backtick not escaped in bash fence output'
+      )
+    })
+
+    test('does not escape ${...} in js fences (intended interpolation)', () => {
+      const result = transformMarkdown(
+        '```js\nconsole.log(`${process.env.HOME}`)\n```'
+      )
+      assert.ok(
+        result.includes('${process.env.HOME}'),
+        'JS interpolation was incorrectly escaped in js fence'
+      )
+    })
+
+    test('bash fence $VAR and $(cmd) pass through unmodified', () => {
+      const result = transformMarkdown(
+        '```bash\necho $HOME\necho $(whoami)\n```'
+      )
+      assert.ok(result.includes('echo $HOME'), '$VAR incorrectly modified')
+      assert.ok(result.includes('echo $(whoami)'), '$() incorrectly modified')
+    })
+  })
 })


### PR DESCRIPTION
Bash fence blocks in `transformMarkdown()` embed content inside a JS tagged template literal (`await $`...``). This means `${...}` and
Backtick characters in bash fence content were interpreted as JS template literal syntax rather than literal shell text.

This commit escapes `\`, `` ` ``, and `${` in bash fence lines before embedding them in the template literal, so the content is always
treated as literal shell commands.

Normal shell syntax (`$VAR`, `$(cmd)`) is unaffected.

Security regression tests added to `test/md.test.ts`.