### PR TITLE
fix(deps): skip node: protocol imports in --install

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -33,7 +33,7 @@
       "build/globals.js",
       "build/deno.js"
     ],
-    "limit": "881.40 kB",
+    "limit": "881.42 kB",
     "brotli": false,
     "gzip": false
   },
@@ -66,7 +66,7 @@
       "README.md",
       "LICENSE"
     ],
-    "limit": "944.14 kB",
+    "limit": "944.17 kB",
     "brotli": false,
     "gzip": false
   }

--- a/build/deps.cjs
+++ b/build/deps.cjs
@@ -62,7 +62,7 @@ function parseDeps(content) {
 }
 function parsePackageName(path) {
   var _a, _b;
-  if (!path) return;
+  if (!path || path.includes(":")) return;
   const name = (_b = (_a = nameRe.exec(path)) == null ? void 0 : _a.groups) == null ? void 0 : _b.name;
   if (name && !builtins.has(name)) return name;
 }

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -86,7 +86,7 @@ export function parseDeps(content: string): Record<string, string> {
 }
 
 function parsePackageName(path?: string): string | undefined {
-  if (!path) return
+  if (!path || path.includes(':')) return
 
   const name = nameRe.exec(path)?.groups?.name
   if (name && !builtins.has(name)) return name

--- a/test/deps.test.js
+++ b/test/deps.test.js
@@ -120,6 +120,12 @@ describe('deps', () => {
         [`require('@')`, {}],
         [`require('@/_foo')`, {}],
         [`require('@foo')`, {}],
+        // ignores protocol specifiers
+        [`import fs from 'node:fs'`, {}],
+        [`require('node:path')`, {}],
+        [`import('node:crypto')`, {}],
+        [`import { promises } from 'node:fs/promises'`, {}],
+        [`import * as assert from 'node:assert/strict'`, {}],
       ].forEach(([input, result]) => {
         assert.deepEqual(parseDeps(input), result)
       })


### PR DESCRIPTION
Fixes #1462

```ts
import fs from "node:fs"
import path from "node:path"
// zx --install no longer tries to install `node@latest`
```

`parsePackageName()` now returns early when the import specifier contains `:`, since npm package names cannot contain colons. This skips all protocol imports (`node:`, `npm:`, `jsr:`, `file:`) without being affected by the build pipeline's `replaceAll("node:", "")` post-processing step.

- [x] **Setup** Set the latest Node.js LTS version.
- [x] **Build**: I've run `npm build` before committing and verified the bundle updates correctly.
- [x] **Tests**: I've run `test` and confirmed all tests succeed. Added tests to cover my changes if needed.
- [x] **Docs**: I've added or updated relevant documentation as needed.
- [x] **Sign** Commits have verified signatures and follow conventional commits spec
- [x] **CoC**: My changes follow the project's coding guidelines and Code of Conduct.
- [x] **Review**: This PR represents original work and is not solely generated by AI tools.