### PR TITLE
fix(cli): avoid dangling symlink temp path

### DIFF
--- a/build/cli.cjs
+++ b/build/cli.cjs
@@ -356,7 +356,16 @@ function getFilepath(cwd = ".", name = "zx", _ext) {
   return [
     name + ext,
     name + "-" + (0, import_util2.randomId)() + ext
-  ].map((f) => import_index.path.resolve(import_node_process2.default.cwd(), cwd, f)).find((f) => !import_index.fs.existsSync(f));
+  ].map((f) => import_index.path.resolve(import_node_process2.default.cwd(), cwd, f)).find((f) => !existsNoFollow(f));
+}
+function existsNoFollow(p) {
+  try {
+    import_index.fs.lstatSync(p);
+    return true;
+  } catch (err) {
+    if (err?.code === "ENOENT") return false;
+    throw err;
+  }
 }
 /* c8 ignore next 100 */
 // Annotate the CommonJS export names for ESM import in node:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -294,5 +294,15 @@ function getFilepath(cwd = '.', name = 'zx', _ext?: string): string {
     name + '-' + randomId() + ext,
   ]
     .map(f => path.resolve(process.cwd(), cwd, f))
-    .find(f => !fs.existsSync(f))!
+    .find(f => !existsNoFollow(f))!
+}
+
+function existsNoFollow(p: string): boolean {
+  try {
+    fs.lstatSync(p)
+    return true
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return false
+    throw err
+  }
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -367,6 +367,31 @@ console.log(a);
     assert.equal((await $`node build/cli.js -e='echo(69)'`).stdout, '69\n')
   })
 
+  test('eval does not write through dangling symlink temp path', async (t) => {
+    const cwd = tmpdir()
+    const target = path.join(cwd, 'created-through-symlink')
+    const link = path.join(cwd, 'zx.mjs')
+
+    try {
+      fs.symlinkSync(target, link)
+    } catch {
+      await fs.remove(cwd)
+      t.skip('symlink creation is unavailable')
+      return
+    }
+
+    try {
+      const out =
+        await $`node build/cli.js --cwd=${cwd} --eval 'console.log("ok")'`
+
+      assert.equal(out.stdout, 'ok\n')
+      assert.equal(fs.existsSync(target), false)
+      assert.equal(fs.lstatSync(link).isSymbolicLink(), true)
+    } finally {
+      await fs.remove(cwd)
+    }
+  })
+
   test('eval works with stdin', async () => {
     const p = $`(printf foo; sleep 0.1; printf bar) | node build/cli.js --eval 'echo(await stdin())'`
     assert.equal((await p).stdout, 'foobar\n')


### PR DESCRIPTION
**Title**
Fix dangling symlink handling for CLI temporary script paths

**Description**
This PR fixes a symlink-handling issue in the CLI temporary script file path selection used by `--eval`, stdin, and remote script execution.

Previously, `getFilepath()` used `fs.existsSync()` to determine whether a candidate temp path such as `zx.mjs` was available. `existsSync()` returns `false` for dangling symlinks, which meant a pre-existing dangling symlink could be treated as a free path. The subsequent `fs.writeFile()` call would then follow the symlink and create the symlink target.

This change replaces that availability check with an `lstatSync()`-based helper, so symlinks, including dangling symlinks, are treated as occupied paths and skipped.

**Changes**
- Use `lstatSync()` instead of `existsSync()` when checking CLI temp path availability.
- Mirror the generated `build/cli.cjs` output.
- Add a regression test covering `--eval` with a dangling `zx.mjs` symlink.

**Security Impact**
Prevents attacker-controlled dangling symlinks in the working directory from being selected as temporary script paths and written through during CLI execution.

**Testing**
- `npx prettier --check src/cli.ts test/cli.test.js`
- `npx tsc --project tsconfig.json --noEmit`
- Focused regression test added for dangling symlink temp path handling.