### PR TITLE
docs(api): fix tmpfile('f2.txt') example to show matching output filename

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -328,7 +328,7 @@ Temp file factory.
 
 ```js
 f1 = tmpfile()         // /os/based/tmp/zx-1ra1iofojgg
-f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/foo.txt
+f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/f2.txt
 f3 = tmpfile('f3.txt', 'string or buffer')
 f4 = tmpfile('f4.sh', 'echo "foo"', 0o744) // executable
 ```


### PR DESCRIPTION
Fixes #1469.

In `docs/api.md` under the `tmpfile()` section (line 331), the inline comment showed an output filename that didn't match the input argument — `tmpfile('f2.txt')` was annotated with a path ending in `foo.txt`. Since `tempfile(name)` in `src/goods.ts` does `path.join(tempdir(), name)`, the result for `tmpfile('f2.txt')` ends in `f2.txt`.

```diff
- f2 = tmpfile('f2.txt')   // /os/based/tmp/zx-1ra1iofojgg/foo.txt
+ f2 = tmpfile('f2.txt')   // /os/based/tmp/zx-1ra1iofojgg/f2.txt
```