### PR TITLE
fix(md): require 4+ spaces for indented code blocks (CommonMark)

### DIFF
--- a/src/md.ts
+++ b/src/md.ts
@@ -17,7 +17,7 @@ import { bufToString } from './util.ts'
 
 export function transformMarkdown(buf: Buffer | string): string {
   const out: string[] = []
-  const tabRe = /^(    +|\t)/
+  const tabRe = /^( {4,}|\t)/
   const fenceRe =
     /^(?<indent> {0,3})(?<fence>(`{3,20}|~{3,20}))(?:(?<js>js|javascript|ts|typescript)|(?<bash>sh|shell|bash)|.*)$/
 

--- a/src/md.ts
+++ b/src/md.ts
@@ -17,7 +17,7 @@ import { bufToString } from './util.ts'
 
 export function transformMarkdown(buf: Buffer | string): string {
   const out: string[] = []
-  const tabRe = /^(  +|\t)/
+  const tabRe = /^(    +|\t)/
   const fenceRe =
     /^(?<indent> {0,3})(?<fence>(`{3,20}|~{3,20}))(?:(?<js>js|javascript|ts|typescript)|(?<bash>sh|shell|bash)|.*)$/
 

--- a/test/md.test.ts
+++ b/test/md.test.ts
@@ -22,8 +22,21 @@ describe('transformMarkdown()', () => {
       assert.equal(transformMarkdown('\n'), '// \n// ')
     })
 
-    test('preserves tab-indented blocks after a blank line (legacy behavior)', () => {
-      assert.equal(transformMarkdown('  \n    '), '  \n    ')
+    test('preserves 4+ space indented blocks after a blank line (CommonMark)', () => {
+      assert.equal(transformMarkdown('    \n    '), '    \n    ')
+    })
+
+    test('does NOT treat 2-space indented list-item continuation as code (#1388)', () => {
+      // CommonMark: indented code blocks require 4+ spaces. A 2-space-indented
+      // line after a blank line under a list item is list continuation prose,
+      // not code. Treating it as code throws SyntaxError on the next eval.
+      const input = `- on localhost
+
+  This assumes you have a local node running
+`
+      const result = transformMarkdown(input)
+      // Prose line must be commented, not left as raw code.
+      assert.ok(!/^  This assumes/m.test(result), 'expected prose line to not be left as raw code')
     })
 
     test('does not treat a mid-paragraph fence as a fenced block (legacy behavior)', () => {


### PR DESCRIPTION
Fixes #1388.

## Problem

`transformMarkdown()` in `src/md.ts` treats any line indented with **2 or more** spaces (after a blank line) as a markdown indented code block — i.e. raw JS to execute. CommonMark requires 4 or more spaces for an indented code block.

The 2-space cutoff incorrectly captures list-item continuation lines, which are conventionally indented 2 spaces to align with the content after `- `. Those continuation lines are prose, not code, but the parser hands them to the JS engine as raw code and the script blows up with `SyntaxError: Unexpected identifier '<word>'`.

The reporter's case is a README with prose continuation under a list item followed by a fenced shell block. The prose line begins with two spaces, so the old regex treated it as executable code.

## Fix

```diff
-  const tabRe = /^(  +|\t)/
+  const tabRe = /^( {4,}|\t)/
```

Aligns the indented-code-block threshold with CommonMark: 4+ spaces or 1 tab. Tab-indented blocks keep working unchanged.

## Test plan

- [x] Updated the existing tab-indented block test to assert the new CommonMark-compliant 4-space behavior.
- [x] Added a regression test for 2-space indented list-item continuation prose from #1388.
- [x] Existing fenced-code-block and plain-line transform tests still pass.
