### PR TITLE
fix(cli): detect Deno JSR cli entrypoint

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -33,7 +33,7 @@
       "build/globals.js",
       "build/deno.js"
     ],
-    "limit": "881.42 kB",
+    "limit": "881.97 kB",
     "brotli": false,
     "gzip": false
   },
@@ -66,7 +66,7 @@
       "README.md",
       "LICENSE"
     ],
-    "limit": "944.17 kB",
+    "limit": "944.71 kB",
     "brotli": false,
     "gzip": false
   }

--- a/build/cli.cjs
+++ b/build/cli.cjs
@@ -339,6 +339,7 @@ function injectGlobalRequire(origin) {
 }
 function isMain(meta = import_meta_url, scriptpath = import_node_process2.default.argv[1]) {
   if (typeof meta === "string") {
+    if (isDenoJsrMain(meta)) return true;
     if (meta.startsWith("file:")) {
       const modulePath = import_node_url.default.fileURLToPath(meta).replace(/\.\w+$/, "");
       const mainPath = import_index.fs.realpathSync(scriptpath).replace(/\.\w+$/, "");
@@ -346,10 +347,19 @@ function isMain(meta = import_meta_url, scriptpath = import_node_process2.defaul
     }
     return false;
   }
-  return !!meta.main;
+  return !!meta.main || isDenoJsrMain(meta.url);
 }
 function normalizeExt(ext) {
   return ext ? import_index.path.parse(`foo.${ext}`).ext : ext;
+}
+function isDenoJsrMain(metaUrl) {
+  var _a2;
+  const mainModule = (_a2 = globalThis.Deno) == null ? void 0 : _a2.mainModule;
+  if (!(mainModule == null ? void 0 : mainModule.startsWith("jsr:@webpod/zx"))) return false;
+  const normalize = (s) => s.replace("/./", "/").replace(/\/\.?$/, "");
+  const main2 = normalize(mainModule);
+  const current = normalize(metaUrl);
+  return current === "jsr:@webpod/zx/cli" && (main2 === "jsr:@webpod/zx" || main2 === "jsr:@webpod/zx/cli");
 }
 function getFilepath(cwd = ".", name = "zx", _ext) {
   const ext = _ext || argv.ext || EXT;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -270,6 +270,8 @@ export function isMain(
   scriptpath: string = process.argv[1]
 ): boolean {
   if (typeof meta === 'string') {
+    if (isDenoJsrMain(meta)) return true
+
     if (meta.startsWith('file:')) {
       const modulePath = url.fileURLToPath(meta).replace(/\.\w+$/, '')
       const mainPath = fs.realpathSync(scriptpath).replace(/\.\w+$/, '')
@@ -279,11 +281,26 @@ export function isMain(
     return false
   }
 
-  return !!meta.main
+  return !!meta.main || isDenoJsrMain(meta.url)
 }
 
 export function normalizeExt(ext?: string): string | undefined {
   return ext ? path.parse(`foo.${ext}`).ext : ext
+}
+
+function isDenoJsrMain(metaUrl: string): boolean {
+  const mainModule = (globalThis as { Deno?: { mainModule?: string } }).Deno
+    ?.mainModule
+  if (!mainModule?.startsWith('jsr:@webpod/zx')) return false
+
+  const normalize = (s: string) => s.replace('/./', '/').replace(/\/\.?$/, '')
+  const main = normalize(mainModule)
+  const current = normalize(metaUrl)
+
+  return (
+    current === 'jsr:@webpod/zx/cli' &&
+    (main === 'jsr:@webpod/zx' || main === 'jsr:@webpod/zx/cli')
+  )
 }
 
 // prettier-ignore

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -445,6 +445,23 @@ console.log(a);
       assert.equal(isMain('///root/zx/test/cli.test.js'), false)
     })
 
+    test('isMain() accepts Deno JSR cli entrypoints', () => {
+      const deno = globalThis.Deno
+      globalThis.Deno = { mainModule: 'jsr:@webpod/zx' }
+      try {
+        assert.equal(isMain('jsr:@webpod/zx/cli'), true)
+        assert.equal(isMain('jsr:@webpod/zx/./cli'), true)
+
+        globalThis.Deno.mainModule = 'jsr:@webpod/zx/.'
+        assert.equal(isMain('jsr:@webpod/zx/cli'), true)
+
+        globalThis.Deno.mainModule = 'jsr:@webpod/zx/core'
+        assert.equal(isMain('jsr:@webpod/zx/cli'), false)
+      } finally {
+        globalThis.Deno = deno
+      }
+    })
+
     test('normalizeExt()', () => {
       assert.equal(normalizeExt('.ts'), '.ts')
       assert.equal(normalizeExt('ts'), '.ts')


### PR DESCRIPTION
Fixes #1383.

## What changed

`isMain()` now recognizes Deno JSR executions where the main module is reported as `jsr:@webpod/zx`, `jsr:@webpod/zx/.`, or `jsr:@webpod/zx/cli`.

This keeps the existing Node/file-url behavior unchanged, but lets the CLI autorun when `zx` is launched through its JSR entrypoint.

## Why

When running through JSR, Deno does not always expose the CLI as a local file path. The old `isMain()` check only handled local file URLs or `import.meta.main`, so `deno run jsr:@webpod/zx` could import the module without entering the CLI path.

## Usage demo

```ts
import { isMain } from 'zx/cli'

// Simulates Deno reporting the JSR package root as the main module.
globalThis.Deno = { mainModule: 'jsr:@webpod/zx' }
console.log(isMain('jsr:@webpod/zx/cli')) // true
```

- [x] **Setup** Set the latest Node.js LTS version.
- [x] **Build**: I’ve run `npm build` before committing and verified the bundle updates correctly.
- [x] **Tests**: I’ve run focused tests and size checks. Added regression coverage for the JSR main-module cases.
- [x] **Docs**: Not needed; this is a CLI entrypoint fix covered by tests.
- [x] **Sign** Commits have verified signatures and follow conventional commits spec.
- [x] **CoC**: My changes follow the project’s coding guidelines and Code of Conduct.
- [x] **Review**: This PR represents original work and is not solely generated by AI tools.
