### PR TITLE
docs(api): fix tmpfile() example to show matching output filename

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -328,7 +328,7 @@ Temp file factory.
 
 ```js
 f1 = tmpfile()         // /os/based/tmp/zx-1ra1iofojgg
-f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/foo.txt
+f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/f2.txt
 f3 = tmpfile('f3.txt', 'string or buffer')
 f4 = tmpfile('f4.sh', 'echo "foo"', 0o744) // executable
 ```


### PR DESCRIPTION
Fixes #1469

Corrects the inline comment in `docs/api.md` under the `tmpfile()` section. 

The example showed `tmpfile('f2.txt')` resulting in a path ending in `foo.txt`, which doesn't match the passed argument. Under the hood, `tempfile(name)` returns `path.join(tempdir(), name)`, so the returned path should end in `f2.txt`. This PR fixes the comment to accurately reflect the implementation.


```ts
import { tmpfile } from 'zx'

const f2 = tmpfile('f2.txt')  // -> /os/based/tmp/zx-1ra1iofojgg/f2.txt