### PR TITLE
docs: correct tmpfile example output

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -328,7 +328,7 @@ Temp file factory.
 
 ```js
 f1 = tmpfile()         // /os/based/tmp/zx-1ra1iofojgg
-f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/foo.txt
+f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/f2.txt
 f3 = tmpfile('f3.txt', 'string or buffer')
 f4 = tmpfile('f4.sh', 'echo "foo"', 0o744) // executable
 ```


### PR DESCRIPTION
﻿## Problem

The `tmpfile('f2.txt')` example in `docs/api.md` shows a returned path ending in `foo.txt`, which does not match the argument.

## Root cause

The example comment appears to have been copied from the `tmpdir('foo')` example above it, while `tmpfile(name)` returns a path using the provided file name.

## Solution

Update the example output to end in `f2.txt`.

## Tests run

- `npm exec --yes prettier -- --check docs/api.md`
- `git diff --check`

Fixes #1469
