### PR TITLE
docs: explain syncProcessCwd async contexts

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -240,6 +240,49 @@ syncProcessCwd()
 syncProcessCwd(false) // pass false to disable the hook
 ```
 
+Use this when code inside separate async contexts relies on `process.cwd()` or
+relative paths in Node APIs. Without the hook, `cd()` still changes the process
+directory globally, while `within()` restores only the internal `$` context:
+
+```js
+const start = process.cwd()
+
+await within(async () => {
+  cd('/tmp/project')
+  await fs.pathExists('package.json') // resolves from /tmp/project
+})
+
+await within(async () => {
+  process.cwd() // => /tmp/project
+  await $`pwd` // => start
+})
+```
+
+With the hook enabled, each async callback gets `process.cwd()` restored from
+the `$` context before it runs:
+
+```js
+syncProcessCwd()
+
+try {
+  await within(async () => {
+    cd('/tmp/project')
+    await fs.pathExists('package.json') // resolves from /tmp/project
+  })
+
+  await within(async () => {
+    process.cwd() // => start
+    await $`pwd` // => start
+  })
+} finally {
+  syncProcessCwd(false)
+}
+```
+
+If only `zx` commands need a different directory, prefer setting `$.cwd` inside
+the `within()` callback. Enable `syncProcessCwd()` when non-`zx` code also needs
+relative paths to follow that context.
+
 > This feature is disabled by default because of performance overhead.
 
 ## `retry()`


### PR DESCRIPTION
﻿## Problem

Issue #876 notes that the current docs mention `cd()` and `syncProcessCwd()`, but do not explain the async-context mismatch that can happen when `cd()` changes the global process directory while `within()` restores only zx's internal `$` context.

## Root cause

The `syncProcessCwd()` section only states what the hook does. It does not show how `process.cwd()` can drift from `$` in separate callbacks, or when users should prefer `$.cwd` instead.

## Solution

Add examples showing the mismatch without the hook and the restored behavior with `syncProcessCwd()` enabled, plus guidance to use `$.cwd` for zx-only directory changes.

## Tests run

- `npm exec --yes prettier -- --check docs/api.md`
- `git diff --check`

Fixes #876
