### PR TITLE
docs: clarify multiline command continuations

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,6 +99,18 @@ const flags = [
 await $`git log ${flags}`
 ```
 
+For a long command, use the shell's line-continuation syntax. Keep the
+backslash as the final character on each continued line; trailing spaces after
+the backslash make the shell treat the next line as a separate command.
+
+```js
+const preview = 'cat {2}'
+
+await $`fzf \
+  --preview=${preview} \
+  --with-nth=1`
+```
+
 In async mode, zx awaits any `thenable` in literal before executing the command.
 ```js
 const a1 = $`echo foo`


### PR DESCRIPTION
Fixes #1149

## Problem
The getting-started guide shows arrays for long argument lists, but it does not show how to split one shell command across multiple lines. This makes it easy to write a backslash followed by trailing spaces and accidentally start a new shell command on the next line.

## Root cause
zx passes literal command text to the configured shell. A newline is treated by the shell as a command separator unless it is escaped, and a backslash only continues the line when it is the final character before the newline.

## Solution
Add a concise multiline `fzf` example and call out that trailing spaces after the continuation backslash break the command.

## Tests run
- `npx prettier --check docs/getting-started.md`
- `git diff --check HEAD~1..HEAD`
- Attempted `npm run docs:build`; it fails on the current checkout in Vite/esbuild while transforming generated VitePress app destructuring, before this Markdown content is involved.