### PR TITLE
fix: parse markdown list continuation prose

### DIFF
--- a/src/md.ts
+++ b/src/md.ts
@@ -17,7 +17,7 @@ import { bufToString } from './util.ts'
 
 export function transformMarkdown(buf: Buffer | string): string {
   const out: string[] = []
-  const tabRe = /^(  +|\t)/
+  const tabRe = /^( {4,}|\t)/
   const fenceRe =
     /^(?<indent> {0,3})(?<fence>(`{3,20}|~{3,20}))(?:(?<js>js|javascript|ts|typescript)|(?<bash>sh|shell|bash)|.*)$/
 

--- a/test/md.test.ts
+++ b/test/md.test.ts
@@ -22,8 +22,38 @@ describe('transformMarkdown()', () => {
       assert.equal(transformMarkdown('\n'), '// \n// ')
     })
 
-    test('preserves tab-indented blocks after a blank line (legacy behavior)', () => {
-      assert.equal(transformMarkdown('  \n    '), '  \n    ')
+    test('preserves four-space and tab-indented blocks after a blank line', () => {
+      assert.equal(
+        transformMarkdown('\n    code\n\tmore'),
+        '// \n    code\n\tmore'
+      )
+    })
+
+    test('comments two-space indented list continuation prose', () => {
+      const result = transformMarkdown(`
+- on localhost
+
+  This assumes you have a local node running.
+
+  \`\`\`bash
+  pnpm run contracts:deploy localhost
+  \`\`\`
+`)
+
+      assert.equal(
+        result,
+        [
+          '// ',
+          '// - on localhost',
+          '// ',
+          '//   This assumes you have a local node running.',
+          '// ',
+          'await $`',
+          'pnpm run contracts:deploy localhost',
+          '`',
+          '// ',
+        ].join('\n')
+      )
     })
 
     test('does not treat a mid-paragraph fence as a fenced block (legacy behavior)', () => {


### PR DESCRIPTION
## Problem

Markdown scripts that contain two-space-indented list continuation prose can be parsed as executable code after a blank line. That matches the failure in #1388, where prose under a list item is emitted without a comment prefix. It also affects #1389, where an indented bash fence is transformed into malformed `$` template-call output.

## Root cause

The markdown transformer treated any line starting with two or more spaces as an indented code block after an empty line. CommonMark indented code blocks require four spaces or a tab, while fenced blocks may still be indented by up to three spaces.

## Solution

Only enter indented-code mode for four or more leading spaces or a tab. The existing fenced-code parser continues to handle fences indented by up to three spaces, so indented bash fences inside list content still transform correctly.

Fixes #1388
Fixes #1389

## Tests

- `node --experimental-transform-types test/md.test.ts`
- `npx prettier --check src\md.ts test\md.test.ts`
- `git diff --check`