### PR TITLE
fix: make build tooling paths portable

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,7 +138,7 @@ In the early stages of the project, we [had some difficulties](https://dev.to/an
 Corresponding tasks are defined in the `package.json.scripts`:
 ```json
 {
-  "prebuild":     "rm -rf build",
+  "prebuild":     "node -e \"require('node:fs').rmSync('build', { recursive: true, force: true })\"",
   "build":        "npm run build:js && npm run build:dts && npm run build:tests",
   "build:js":     "node scripts/build-js.mjs --format=cjs --hybrid --entry=src/*.ts:!src/error.ts:!src/repl.ts:!src/md.ts:!src/log.ts:!src/globals-jsr.ts:!src/goods.ts && npm run build:vendor",
   "build:vendor": "node scripts/build-js.mjs --format=cjs --entry=src/vendor-*.ts --bundle=all --external='./internals.ts'",
@@ -188,7 +188,7 @@ Static analyzers are responsible for code quality.
 ```json
 {
   "fmt:check": "prettier --check .",
-  "test:circular": "madge --circular src/*"
+  "test:circular": "madge --circular --extensions ts src"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "scripts": {
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
-    "prebuild": "rm -rf build",
+    "prebuild": "node -e \"require('node:fs').rmSync('build', { recursive: true, force: true })\"",
     "build": "npm run build:versions && npm run build:js && npm run build:dts && npm run build:tests",
     "build:js": "node scripts/build-js.mjs --format=cjs --hybrid --entry='src/{cli,core,deps,globals,index,internals,util,vendor*}.ts' && npm run build:vendor",
     "build:vendor": "node scripts/build-js.mjs --format=cjs --entry=src/vendor-*.ts --bundle=all --external='./internals.ts'",
@@ -93,7 +93,7 @@
     "test:dcr": "node ./test/it/build-dcr.test.js",
     "test:unit": "node --experimental-transform-types ./test/all.test.js",
     "test:coverage": "c8 -c .nycrc --check-coverage npm run test:unit",
-    "test:circular": "madge --circular src/*",
+    "test:circular": "madge --circular --extensions ts src",
     "test:types": "tsd",
     "test:license": "node ./test/extra.test.js",
     "test:audit": "node scripts/npm-audit.js",

--- a/scripts/build-js.mjs
+++ b/scripts/build-js.mjs
@@ -16,6 +16,7 @@
 
 import path from 'node:path'
 import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import esbuild from 'esbuild'
 import { injectCode, injectFile } from 'esbuild-plugin-utils'
 import { nodeExternalsPlugin } from 'esbuild-node-externals'
@@ -27,7 +28,7 @@ import esbuildResolvePlugin from 'esbuild-plugin-resolve'
 import minimist from 'minimist'
 import glob from 'fast-glob'
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const argv = minimist(process.argv.slice(2), {
   default: {

--- a/scripts/build-jsr.mjs
+++ b/scripts/build-jsr.mjs
@@ -14,7 +14,9 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const root = path.resolve(__dirname, '..')
 const pkgJson = JSON.parse(
   fs.readFileSync(path.resolve(root, 'package.json'), 'utf-8')

--- a/scripts/build-pkgjson-lite.mjs
+++ b/scripts/build-pkgjson-lite.mjs
@@ -16,9 +16,10 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { depseekSync } from 'depseek'
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const root = path.resolve(__dirname, '..')
 const source = 'package.json'
 const dest = 'package-lite.json'

--- a/scripts/build-pkgjson-main.mjs
+++ b/scripts/build-pkgjson-main.mjs
@@ -16,8 +16,9 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const root = path.resolve(__dirname, '..')
 const source = 'package.json'
 const dest = 'package-main.json'

--- a/scripts/build-size-limit.mjs
+++ b/scripts/build-size-limit.mjs
@@ -17,8 +17,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 
-const root = path.resolve(new URL(import.meta.url).pathname, '../..')
+const root = path.resolve(fileURLToPath(import.meta.url), '../..')
 const configPath = path.join(root, '.size-limit.json')
 const original = fs.readFileSync(configPath, 'utf8')
 const config = JSON.parse(original)

--- a/scripts/build-tests.mjs
+++ b/scripts/build-tests.mjs
@@ -16,6 +16,7 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import * as core from '../build/core.js'
 import * as cli from '../build/cli.js'
 import * as index from '../build/index.js'
@@ -26,7 +27,7 @@ const modules = [
   ['cli', cli],
   ['index', index],
 ]
-const root = path.resolve(new URL(import.meta.url).pathname, '../..')
+const root = path.resolve(fileURLToPath(import.meta.url), '../..')
 const filePath = path.resolve(root, `test/export.test.js`)
 
 const copyright = fs.readFileSync(

--- a/scripts/build-versions.mjs
+++ b/scripts/build-versions.mjs
@@ -16,9 +16,10 @@
 
 import fs from 'fs-extra'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import minimist from 'minimist'
 
-const root = path.resolve(new URL(import.meta.url).pathname, '../..')
+const root = path.resolve(fileURLToPath(import.meta.url), '../..')
 const copyright = fs.readFileSync(
   path.resolve(root, 'test/fixtures/copyright.txt'),
   'utf8'

--- a/test/extra.test.js
+++ b/test/extra.test.js
@@ -14,9 +14,10 @@
 
 import assert from 'node:assert'
 import { test, describe } from 'node:test'
+import { fileURLToPath } from 'node:url'
 import { globby, fs, path } from '../build/index.js'
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 describe('extra', () => {
   test('every file should have a license', async () => {

--- a/test/it/build-jsr.test.js
+++ b/test/it/build-jsr.test.js
@@ -14,8 +14,9 @@
 
 import { tempdir, $, path, fs } from '../../build/index.js'
 import { describe, before, after, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const root = path.resolve(__dirname, '../../')
 
 describe('jsr artifact', () => {


### PR DESCRIPTION
## Problem

Some repo build and test tooling assumes POSIX shell/path behavior. On Windows, that can break before the intended command runs:

- `prebuild` uses `rm -rf build`.
- Several scripts convert `import.meta.url` with `new URL(...).pathname`, which produces invalid filesystem paths for Windows drive-letter paths.
- `test:circular` relies on shell glob expansion for `src/*`.

## Root cause

URL pathnames are not filesystem paths on all platforms, and npm scripts should not depend on shell-specific cleanup or glob expansion for these commands.

## Solution

- Use `fileURLToPath(import.meta.url)` before passing module paths to `node:path`.
- Replace the prebuild cleanup with `fs.rmSync(..., { recursive: true, force: true })` through Node.
- Run Madge against the `src` directory with explicit TypeScript extensions.
- Keep the architecture script reference in sync with `package.json`.

## Tests

- `npm run build:versions`
- `npm run test:license`
- `npm run test:circular`
- `npm run test:size`
- `node --check` on modified scripts/tests
- `npx prettier --check package.json docs\architecture.md scripts\build-js.mjs scripts\build-jsr.mjs scripts\build-pkgjson-lite.mjs scripts\build-pkgjson-main.mjs scripts\build-size-limit.mjs scripts\build-tests.mjs scripts\build-versions.mjs test\extra.test.js test\it\build-jsr.test.js`
- `git diff --check`