### PR TITLE
chore: remove create-require dependency and refactor imports

### DIFF
--- a/build/3rd-party-licenses
+++ b/build/3rd-party-licenses
@@ -35,11 +35,6 @@ chalk@5.6.2
   chalk/chalk
   MIT
 
-create-require@1.1.1
-  Maël Nison <nison.mael@gmail.com>, Paul Soporan <paul.soporan@gmail.com>, Pooya Parsa <pyapar@gmail.com>
-  nuxt-contrib/create-require
-  MIT
-
 envapi@0.2.3
   Anton Golub <antongolub@antongolub.com>
   git+https://github.com/webpod/envapi.git

--- a/build/vendor-extra.cjs
+++ b/build/vendor-extra.cjs
@@ -8475,47 +8475,6 @@ var require_lib = __commonJS({
   }
 });
 
-// node_modules/create-require/create-require.js
-var require_create_require = __commonJS({
-  "node_modules/create-require/create-require.js"(exports2, module2) {
-    "use strict";
-    var nativeModule = require("module");
-    var path5 = require("path");
-    var fs6 = require("fs");
-    function createRequire2(filename) {
-      if (!filename) {
-        filename = process.cwd();
-      }
-      if (isDir(filename)) {
-        filename = path5.join(filename, "index.js");
-      }
-      if (nativeModule.createRequire) {
-        return nativeModule.createRequire(filename);
-      }
-      if (nativeModule.createRequireFromPath) {
-        return nativeModule.createRequireFromPath(filename);
-      }
-      return _createRequire2(filename);
-    }
-    function _createRequire2(filename) {
-      const mod = new nativeModule.Module(filename, null);
-      mod.filename = filename;
-      mod.paths = nativeModule.Module._nodeModulePaths(path5.dirname(filename));
-      mod._compile("module.exports = require;", filename);
-      return mod.exports;
-    }
-    function isDir(path6) {
-      try {
-        const stat = fs6.lstatSync(path6);
-        return stat.isDirectory();
-      } catch (e) {
-        return false;
-      }
-    }
-    module2.exports = createRequire2;
-  }
-});
-
 // node_modules/node-fetch-native/dist/shared/node-fetch-native.DfbY2q-x.mjs
 function f(e) {
   return e && e.__esModule && Object.prototype.hasOwnProperty.call(e, "default") ? e.default : e;
@@ -21175,7 +21134,7 @@ function getIndent(level) {
 
 // src/vendor-extra.ts
 var _fs = __toESM(require_lib(), 1);
-var import_create_require = __toESM(require_create_require(), 1);
+var import_node_module = require("module");
 
 // node_modules/node-fetch-native/dist/index.mjs
 init_node();
@@ -21353,7 +21312,7 @@ var import_internals = require("./internals.cjs");
 var { wrap } = import_internals.bus;
 var globalVar = "Deno" in globalThis ? globalThis : global;
 globalVar.AbortController = globalVar.AbortController || T;
-var createRequire = import_create_require.default;
+var createRequire = import_node_module.createRequire;
 var globbyModule = {
   convertPathToPattern,
   globby,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@webpod/ps": "1.2.1",
         "c8": "11.0.0",
         "chalk": "5.6.2",
-        "create-require": "1.1.1",
         "cronometro": "6.0.3",
         "depseek": "0.4.6",
         "dts-bundle-generator": "9.5.1",
@@ -3339,13 +3338,6 @@
         "cosmiconfig": ">=9",
         "typescript": ">=5"
       }
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cronometro": {
       "version": "6.0.3",
@@ -7263,7 +7255,6 @@
         "acorn": "^8.4.1",
         "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
-        "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "v8-compile-cache-lib": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "@webpod/ps": "1.2.1",
     "c8": "11.0.0",
     "chalk": "5.6.2",
-    "create-require": "1.1.1",
     "cronometro": "6.0.3",
     "depseek": "0.4.6",
     "dts-bundle-generator": "9.5.1",

--- a/scripts/build-jsr.mjs
+++ b/scripts/build-jsr.mjs
@@ -33,7 +33,6 @@ const prodDeps = new Set([
   '@webpod/ingrid',
   '@webpod/ps',
   'chalk',
-  'create-require',
   'depseek',
   'envapi',
   'fs-extra',

--- a/src/vendor-extra.ts
+++ b/src/vendor-extra.ts
@@ -28,7 +28,7 @@ import {
 import * as _yaml from 'yaml'
 import * as _maml from 'maml'
 import * as _fs from 'fs-extra'
-import _createRequire from 'create-require'
+import { createRequire as _createRequire } from 'node:module'
 import { fetch as _nodeFetch, AbortController } from 'node-fetch-native'
 import { depseekSync as _depseek } from 'depseek'
 import { default as _minimist } from 'minimist'


### PR DESCRIPTION
This change removes the create-require dependency and replaces its usage with Node.js's native createRequire implementation from node:module.

The project currently specifies a minimum supported Node.js version of 12.17.0, which already includes support for module.createRequire(). As a result, the create-require package is no longer required for compatibility purposes and serves only as an unnecessary dependency.
