### PR TITLE
fix(md): comment out tab-indented blocks instead of executing them

### DIFF
--- a/src/md.ts
+++ b/src/md.ts
@@ -61,7 +61,7 @@ export function transformMarkdown(buf: Buffer | string): string {
         }
 
         if (prevEmpty && tabRe.test(line)) {
-          out.push(line)
+          out.push('// ' + line)
           state = 'tab'
           continue
         }
@@ -73,7 +73,7 @@ export function transformMarkdown(buf: Buffer | string): string {
 
       case 'tab':
         if (line === '') out.push('')
-        else if (tabRe.test(line)) out.push(line)
+        else if (tabRe.test(line)) out.push('// ' + line)
         else {
           out.push('// ' + line)
           state = 'root'

--- a/test/md.test.ts
+++ b/test/md.test.ts
@@ -22,16 +22,28 @@ describe('transformMarkdown()', () => {
       assert.equal(transformMarkdown('\n'), '// \n// ')
     })
 
-    test('preserves tab-indented blocks after a blank line (legacy behavior)', () => {
-      assert.equal(transformMarkdown('  \n    '), '  \n    ')
+    test('comments out tab-indented blocks after a blank line', () => {
+      assert.equal(transformMarkdown('  \n    '), '//   \n//     ')
     })
 
-    test('does not treat a mid-paragraph fence as a fenced block (legacy behavior)', () => {
+    test('does not throw SyntaxError for indented prose text (issue #1388)', () => {
+      const input = '\n    This assumes the environment is configured.'
+      const output = transformMarkdown(input)
+      const lines = output.split('\n')
+      const proseLine = lines.find((l) => l.includes('This assumes'))
+      assert.ok(proseLine, 'line with prose should exist in output')
+      assert.ok(
+        proseLine!.startsWith('//'),
+        'indented prose should be commented out, not executed as JS'
+      )
+    })
+
+    test('does not treat a tab-indented fence marker as a fenced block', () => {
       assert.equal(
         transformMarkdown(`
 \t~~~js
 console.log('js')`),
-        `// \n\t~~~js\n// console.log('js')`
+        `// \n// \t~~~js\n// console.log('js')`
       )
     })
   })


### PR DESCRIPTION
Fixes #1388 / regression: SyntaxError when running zx on markdown files with indented prose

Tab-indented blocks (4 spaces or tab, per CommonMark spec) were pushed verbatim to the JS output and executed. Any prose text in those blocks caused a SyntaxError at runtime. For example, a README with:

    This assumes the environment is configured.

produced: SyntaxError: Unexpected identifier 'assumes'

The fix mirrors the behavior already used for non-JS fenced blocks: prefix each indented line with '// ' so it becomes a comment. Two places in md.ts needed the change: the transition from root to tab state, and the tab state itself.

Updated the existing legacy-behavior test to reflect the new output and added a regression test for the prose-text case.

- [x] **Setup** Set the latest Node.js LTS version.
- [x] **Build**: I've run npm build before committing and verified the bundle updates correctly.
- [x] **Tests**: I've run test and confirmed all tests succeed. Added tests to cover my changes.
- [ ] **Docs**: No documentation change needed for this fix.
- [x] **Sign** Commits follow conventional commits spec.
- [x] **CoC**: My changes follow the project coding guidelines and Code of Conduct.
- [ ] **Review**: This PR represents original work and is not solely generated by AI tools.