### PR TITLE
docs(api): fix tmpfile('f2.txt') example output path

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -328,7 +328,7 @@ Temp file factory.
 
 ```js
 f1 = tmpfile()         // /os/based/tmp/zx-1ra1iofojgg
-f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/foo.txt
+f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/f2.txt
 f3 = tmpfile('f3.txt', 'string or buffer')
 f4 = tmpfile('f4.sh', 'echo "foo"', 0o744) // executable
 ```


### PR DESCRIPTION
## Summary

Fixes incorrect inline comment in the `tmpfile()` docs example.

Fixes #1469

## Problem

`docs/api.md` showed the result path ending in `foo.txt` even though the argument is `'f2.txt'`.

## Root cause

Copy/paste error. `tempfile()` in `src/goods.ts` uses `path.join(tempdir(), name)`, preserving the basename.

## Fix

Update the comment to `.../f2.txt`.

## Testing

Verified against `tempfile()` implementation in `src/goods.ts` (docs-only change).