### PR TITLE
docs(migration-from-v7): fix webpod ssh example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -328,7 +328,7 @@ Temp file factory.
 
 ```js
 f1 = tmpfile()         // /os/based/tmp/zx-1ra1iofojgg
-f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/foo.txt
+f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/f2.txt
 f3 = tmpfile('f3.txt', 'string or buffer')
 f4 = tmpfile('f4.sh', 'echo "foo"', 0o744) // executable
 ```

--- a/docs/migration-from-v7.md
+++ b/docs/migration-from-v7.md
@@ -14,7 +14,7 @@ $.quiet = true   // to completely turn off logging
 // import {ssh} from 'zx' ↓
 import {ssh} from 'webpod'
 
-const remote = ssh('user@host')
+const remote = ssh({remoteUser: 'user', hostname: 'host'})
 await remote`echo foo`
 ```
 


### PR DESCRIPTION
Fixes #1480

Corrects the v7→v8 migration example for `ssh` after the API moved to [webpod](https://github.com/webpod/webpod). `ssh()` expects an options object, not a `user@host` string.

```diff
-const remote = ssh('user@host')
+const remote = ssh({remoteUser: 'user', hostname: 'host'})
```

- [x] **Docs**: updated `docs/migration-from-v7.md`
- [x] **Sign**: commit is SSH-signed
- [x] **CoC**: follows project guidelines

cc @antongolub for docs review