### PR TITLE
fix(util): escape null byte unambiguously in quote()

### DIFF
--- a/build/util.cjs
+++ b/build/util.cjs
@@ -64,7 +64,7 @@ function preferLocalBin(env, ...dirs) {
 function quote(arg) {
   if (arg === "") return `$''`;
   if (/^[\w/.\-+@:=,%]+$/.test(arg)) return arg;
-  return `$'` + arg.replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/\f/g, "\\f").replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t").replace(/\v/g, "\\v").replace(/\0/g, "\\0") + `'`;
+  return `$'` + arg.replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/\f/g, "\\f").replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t").replace(/\v/g, "\\v").replace(/\0/g, "\\000") + `'`;
 }
 function quotePowerShell(arg) {
   if (arg === "") return `''`;

--- a/src/util.ts
+++ b/src/util.ts
@@ -86,7 +86,7 @@ export function quote(arg: string): string {
       .replace(/\r/g, '\\r')
       .replace(/\t/g, '\\t')
       .replace(/\v/g, '\\v')
-      .replace(/\0/g, '\\0') +
+      .replace(/\0/g, '\\000') +
     `'`
   )
 }

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -70,11 +70,15 @@ describe('util', () => {
   test('quote()', () => {
     assert.ok(quote('string') === 'string')
     assert.ok(quote('') === `$''`)
-    assert.ok(quote(`'\f\n\r\t\v\0`) === `$'\\'\\f\\n\\r\\t\\v\\0'`)
+    assert.ok(quote(`'\f\n\r\t\v\0`) === `$'\\'\\f\\n\\r\\t\\v\\000'`)
 
     const allowed =
       'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_/.-+@:=,%'
     assert.equal(quote(allowed), allowed)
+  })
+
+  test('quote() escapes null byte unambiguously', () => {
+    assert.equal(quote('\0' + '123'), `$'\\000123'`)
   })
 
   test('quotePowerShell()', () => {


### PR DESCRIPTION
## Description

`quote()` escapes a NUL byte as `\0`. In bash ANSI-C quoting (`$'...'`), `\0` is a variable-length octal escape that greedily absorbs up to three following octal digits. So a NUL followed by octal digits is misdecoded.

```js
quote('\0' + '123') // => "$'\0123'"
```

Bash reads `$'\0123'` as `\012` (octal for newline, `0x0a`) followed by `3`. The intended NUL is silently turned into a newline and the following `123` is corrupted. Confirmed end to end through zx: `` $`printf '%s' ${'a\0123'}` `` yields the bytes `a`, `0x0a`, `3` instead of a clean value.

## Fix

Emit a fixed three-digit octal `\000` instead of `\0`. Bash octal escapes are at most three digits, so `\000` cannot absorb following digits and the value stays intact.

```diff
-      .replace(/\0/g, '\\0') +
+      .replace(/\0/g, '\\000') +
```

## Test

Extended the `quote()` null-byte case in `test/util.test.js`. It fails before the change (`$'\0123'`, ambiguous) and passes after (`$'\000123'`).
