### PR TITLE
docs(api): fix tmpfile('f2.txt') example output filename

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -328,7 +328,7 @@ Temp file factory.
 
 ```js
 f1 = tmpfile()         // /os/based/tmp/zx-1ra1iofojgg
-f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/foo.txt
+f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/f2.txt
 f3 = tmpfile('f3.txt', 'string or buffer')
 f4 = tmpfile('f4.sh', 'echo "foo"', 0o744) // executable
 ```


### PR DESCRIPTION
## What

Fixes the inline comment in the `tmpfile()` example in `docs/api.md`.

Before:
```js
f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/foo.txt
```
After:
```js
f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/f2.txt
```

## Why

`tmpfile(name)` returns `path.join(tempdir(), name)` (see `src/goods.ts`), so passing `'f2.txt'` yields a path ending in `f2.txt`, not `foo.txt`. Verified by running the built function.

Closes #1469