### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/process-output.md
+++ b/docs/process-output.md
@@ -29,7 +29,7 @@ interface ProcessOutput extends Error {
   
   text(encoding: Encoding = 'utf8'): string
 
-  // Output lines splitted by newline
+  // Output lines split by newline
   lines(delimiter?: string | RegExp): string[]
   
   // combined stdout and stderr


### PR DESCRIPTION
## Summary
I fix spelling mistakes in documentation and changelog text.

Changed files:
- `docs/process-output.md`

## Testing
I run `git diff --check`.
