### PR TITLE
fix(core): preserve binary output in ProcessOutput.buffer()

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -938,7 +938,14 @@ export class ProcessOutput extends Error {
   }
 
   buffer(): Buffer {
-    return Buffer.from(this.stdall)
+    // Reconstruct from the raw store chunks. `this.stdall` is a UTF-8 decoded
+    // string, so building a Buffer from it corrupts any non-UTF-8 output
+    // (each invalid byte becomes U+FFFD). The original chunks are lossless.
+    return Buffer.concat(
+      [...this._dto.store.stdall].map((chunk) =>
+        isString(chunk) ? Buffer.from(chunk) : chunk
+      )
+    )
   }
 
   blob(type = 'text/plain'): Blob {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1526,6 +1526,15 @@ describe('core', () => {
       assert.equal(o.buffer().compare(Buffer.from('foo\n', 'utf-8')), 0)
     })
 
+    test('buffer() preserves non-utf8 bytes', async () => {
+      const bytes = Buffer.from([0xff, 0xfe, 0x81, 0x82]) // invalid utf-8
+      const o = new ProcessOutput({
+        store: { stdall: [bytes], stdout: [bytes], stderr: [] },
+      })
+      assert.equal(o.buffer().toString('hex'), 'fffe8182')
+      assert.equal(o.text('hex'), 'fffe8182')
+    })
+
     test('blob()', async () => {
       const o = new ProcessOutput(null, null, '', '', 'foo\n')
       assert.equal(await o.blob().text(), 'foo\n')


### PR DESCRIPTION
### Problem

`ProcessOutput.buffer()` builds its `Buffer` from `this.stdall`:

```ts
buffer(): Buffer {
  return Buffer.from(this.stdall)
}
```

But `stdall` is a getter that **UTF-8 decodes** the stored chunks
(`bufArrJoin` → `TextDecoder('utf-8').decode`). Any byte that isn't valid
UTF-8 has already been replaced with `U+FFFD` by the time `buffer()` runs, so
the bytes it returns are corrupted — even though the original, lossless chunks
are still sitting in `this._dto.store.stdall`.

`blob()` and `text(<encoding>)` both delegate to `buffer()`, so they are
affected too. These are the documented APIs for getting bytes out of a command:

```js
const png = await $`cat logo.png`.buffer()   // mangled: every non-utf8 byte → ef bf bd
await $`cat logo.png`.text('hex')            // same corruption
```

### Reproduction

```js
const o = await $`node -e ${'process.stdout.write(Buffer.from([255,254,129,130]))'}`
o.buffer().toString('hex')   // 'efbfbdefbfbdefbfbdefbfbd'  ← expected 'fffe8182'
```

### Fix

Reconstruct the `Buffer` from the raw store chunks (which are the original
`string | Buffer` pieces) instead of the decoded string:

```ts
buffer(): Buffer {
  return Buffer.concat(
    [...this._dto.store.stdall].map((chunk) =>
      isString(chunk) ? Buffer.from(chunk) : chunk
    )
  )
}
```

This also fixes `blob()` and `text('hex' | 'base64' | 'latin1' | …)`, which go
through `buffer()`. The plain-text path (`toString()` / `text()`) is unchanged.

### Test

Added a `buffer()` case in `test/core.test.js` asserting that non-UTF-8 bytes
survive `buffer()`/`text('hex')`. Fails on `main`, passes with the fix; the
existing `buffer()`/`text()`/`blob()` string tests still pass.
