### PR TITLE
fix(core): apply chained configurators to the `cmd` log entry

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -19,7 +19,7 @@
       "README.md",
       "LICENSE"
     ],
-    "limit": "129.46 kB",
+    "limit": "129.54 kB",
     "brotli": false,
     "gzip": false
   },
@@ -33,7 +33,7 @@
       "build/globals.js",
       "build/deno.js"
     ],
-    "limit": "881.85 kB",
+    "limit": "881.93 kB",
     "brotli": false,
     "gzip": false
   },
@@ -66,7 +66,7 @@
       "README.md",
       "LICENSE"
     ],
-    "limit": "944.60 kB",
+    "limit": "944.68 kB",
     "brotli": false,
     "gzip": false
   }

--- a/build/core.cjs
+++ b/build/core.cjs
@@ -583,7 +583,8 @@ var _ProcessPromise = class _ProcessPromise extends Promise {
       },
       on: {
         start: () => {
-          $2.log({ kind: "cmd", cmd: $2.cmd, cwd, verbose: self.isVerbose(), id });
+          const log2 = () => $2.log({ kind: "cmd", cmd: $2.cmd, cwd, verbose: self.isVerbose(), id });
+          self.sync ? log2() : queueMicrotask(log2);
           self.timeout($2.timeout, $2.timeoutSignal);
         },
         stdout: (data) => {

--- a/src/core.ts
+++ b/src/core.ts
@@ -360,7 +360,11 @@ export class ProcessPromise extends Promise<ProcessOutput> {
       },
       on: {
         start: () => {
-          $.log({ kind: 'cmd', cmd: $.cmd, cwd, verbose: self.isVerbose(), id })
+          // A process starts eagerly, so chained configurators (`quiet()`, `verbose()`)
+          // are applied after this hook. Defer the entry to pick them up.
+          // Sync mode gets no such chance and needs the cmd logged before its output.
+          const log = () => $.log({ kind: 'cmd', cmd: $.cmd, cwd, verbose: self.isVerbose(), id })
+          self.sync ? log() : queueMicrotask(log)
           self.timeout($.timeout, $.timeoutSignal)
         },
         stdout: (data) => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -517,6 +517,52 @@ describe('core', () => {
         id,
       })
     })
+
+    it('applies chained configurators to the `cmd` entry', async () => {
+      // https://github.com/google/zx/issues/931
+      const entries = []
+      const log = (entry) => entries.push([entry.kind, entry.verbose])
+      const capture = async (p) => {
+        entries.length = 0
+        await p
+        return entries.slice()
+      }
+
+      assert.deepEqual(
+        await capture($({ log, verbose: true })`echo foo`.quiet()),
+        [
+          ['cmd', false],
+          ['stdout', false],
+          ['end', false],
+        ]
+      )
+      assert.deepEqual(
+        await capture($({ log, verbose: true })`echo foo`.verbose(false)),
+        [
+          ['cmd', false],
+          ['stdout', false],
+          ['end', false],
+        ]
+      )
+      assert.deepEqual(
+        await capture(
+          $({ log, verbose: true, quiet: true })`echo foo`.quiet(false)
+        ),
+        [
+          ['cmd', true],
+          ['stdout', true],
+          ['end', true],
+        ]
+      )
+    })
+
+    it('keeps the `cmd` entry ahead of the output in sync mode', () => {
+      const entries = []
+      const log = (entry) => entries.push(entry.kind)
+      $.sync({ log, verbose: true })`echo foo`
+
+      assert.deepEqual(entries, ['cmd', 'stdout', 'end'])
+    })
   })
 
   describe('ProcessPromise', () => {


### PR DESCRIPTION
Fixes #931

### Problem

`.quiet()` / `.verbose()` chained onto a template tag are not reflected in the `cmd` log entry:

```js
$.verbose = true
await $`echo foo`.quiet()   // still prints `$ echo foo`
```

The reporter noticed this in 8.2.0; it still reproduces on `main` (8.9.0).

### Root cause

A process starts eagerly: `$` calls `pp.run()` synchronously inside the template tag (`core.ts`, `$` factory), and `exec()` fires `on.start` in the same tick. So the `cmd` entry is emitted *before* the chained configurators have run, and `isVerbose()` is evaluated against a snapshot that is still the default one.

`stdout` / `stderr` / `end` entries are unaffected because they arrive on later ticks — hence the inconsistency the issue describes, where a single process logs `cmd: verbose=true` next to `stdout: verbose=false`.

Instrumented on `main`:

```
A: before tag
  LOG cmd verbose=true     <- emitted during the tag, before .quiet()
B: after tag, before .quiet()
C: after .quiet()
  LOG stdout verbose=false
  LOG end verbose=false
```

### Fix

Defer the `cmd` entry by one microtask so the synchronous configurator chain is applied first. `queueMicrotask` (not `setImmediate`) keeps the entry ahead of any I/O-driven `stdout`/`stderr`/`end` entry.

Sync mode is excluded: `$.sync` returns `ProcessOutput` rather than a `ProcessPromise`, so there is nothing to chain, and `spawnSync` emits its output in the same tick — deferring there would print the command *after* its output.

Output for the script in the issue now matches the pre-8.2.0 behaviour it documents as expected.

### Trade-off

Output the caller writes synchronously between the tag and the next `await` now lands before the `$ cmd` banner:

```js
const p = $`echo hi`
console.log('---')   // printed before `$ echo hi`
await p
```

That window is one microtask wide, and it is the cost of letting `.quiet()`/`.verbose()` affect the entry they are supposed to affect.

### Tests

- `applies chained configurators to the` `cmd` `entry` — covers all three symptoms from the issue (`.quiet()`, `.verbose(false)`, and `.quiet(false)` re-enabling output). Fails on `main`.
- `keeps the` `cmd` `entry ahead of the output in sync mode` — guards the sync carve-out.
