### PR TITLE
docs: fix tmpfile example comment

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -328,7 +328,7 @@ Temp file factory.
 
 ```js
 f1 = tmpfile()         // /os/based/tmp/zx-1ra1iofojgg
-f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/foo.txt
+f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/f2.txt
 f3 = tmpfile('f3.txt', 'string or buffer')
 f4 = tmpfile('f4.sh', 'echo "foo"', 0o744) // executable
 ```


### PR DESCRIPTION
## What

Fixes #1469. The docs example for `mpfile()` shows the wrong output filename.

## Why

`mpfile('f2.txt')` returns `path.join(tempdir(), 'f2.txt')` (see `src/goods.ts`), so the resulting path ends in `f2.txt`, not `foo.txt`. The inline comment was misleading.

## Checklist
- [x] Verified against `src/goods.ts` implementation