### PR TITLE
Propagate fetch body read errors through pipe streams

### DIFF
--- a/src/goods.ts
+++ b/src/goods.ts
@@ -111,8 +111,12 @@ const responseToReadable = (response: Response, rs: Readable) => {
     return rs
   }
   rs._read = async () => {
-    const result = await reader.read()
-    rs.push(result.done ? null : Buffer.from(result.value))
+    try {
+      const result = await reader.read()
+      rs.push(result.done ? null : Buffer.from(result.value))
+    } catch (err) {
+      rs.destroy(err instanceof Error ? err : new Error(String(err)))
+    }
   }
   return rs
 }


### PR DESCRIPTION
## Summary

`responseToReadable` assigned an async `_read` handler that awaited `reader.read()` without a try/catch. When the response body failed (network drop, abort, corrupted stream), that became an unhandled promise rejection and could crash the Node process.

This catches read failures and calls `rs.destroy(err)` so the error flows through the piped stream instead.

Fixes #1443

## Test plan

1. Review the try/catch around `reader.read()` in `src/goods.ts`
2. Manually: start `fetch(url, { signal }).pipe\`cat\``, abort the signal mid-stream, and confirm the pipe rejects without an unhandledRejection