### PR TITLE
docs(api): fix tmpfile() example shows wrong output filename

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -328,7 +328,7 @@ Temp file factory.
 
 ```js
 f1 = tmpfile()         // /os/based/tmp/zx-1ra1iofojgg
-f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/foo.txt
+f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/f2.txt
 f3 = tmpfile('f3.txt', 'string or buffer')
 f4 = tmpfile('f4.sh', 'echo "foo"', 0o744) // executable
 ```


### PR DESCRIPTION
Fixes #1469

The `tmpfile('f2.txt')` example in the API docs had a copy-paste error —
the comment showed `foo.txt` as the output filename instead of `f2.txt`.

**Before:**
```js
f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/foo.txt
```

**After:**
```js
f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/f2.txt
```

- [x] **Setup** Set the latest Node.js LTS version.
- [x] **Build**: I’ve run `npm build` before committing and verified the bundle updates correctly.
- [x] **Tests**: I’ve `run test` and confirmed all tests succeed. Added tests to cover my changes if needed.
- [x] **Docs**: I’ve added or updated relevant documentation as needed.
- [x] **Sign** Commits have [verified signatures](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/about-commit-signature-verification) and follow [conventinal commits spec](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] **CoC**: My changes follow [the project’s coding guidelines and Code of Conduct](https://github.com/google/zx?tab=coc-ov-file).  
- [x] **Review**: This PR represents original work and is not solely generated by AI tools.