### PR TITLE
fix: parse stdout, not stdall, in ProcessOutput.json()

### DIFF
--- a/build/core.cjs
+++ b/build/core.cjs
@@ -1029,7 +1029,7 @@ var _ProcessOutput = class _ProcessOutput extends Error {
     return !this._dto.error && this.exitCode === 0;
   }
   json() {
-    return JSON.parse(this.stdall);
+    return JSON.parse(this.stdout);
   }
   buffer() {
     return import_node_buffer.Buffer.from(this.stdall);

--- a/src/core.ts
+++ b/src/core.ts
@@ -934,7 +934,7 @@ export class ProcessOutput extends Error {
   }
 
   json<T = any>(): T {
-    return JSON.parse(this.stdall)
+    return JSON.parse(this.stdout)
   }
 
   buffer(): Buffer {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1495,6 +1495,17 @@ describe('core', () => {
       assert.equal(o.toString(), 'foo\n')
     })
 
+    test('json() parses stdout, not the combined stdout+stderr', async () => {
+      const o = new ProcessOutput(
+        0,
+        null,
+        '{"ok":true}',
+        'progress...',
+        'progress...{"ok":true}'
+      )
+      assert.deepEqual(o.json(), { ok: true })
+    })
+
     test('valueOf()', async () => {
       const o = new ProcessOutput(null, null, '', '', 'foo\n')
       assert.equal(o.valueOf(), 'foo')
@@ -1502,7 +1513,13 @@ describe('core', () => {
     })
 
     test('json()', async () => {
-      const o = new ProcessOutput(null, null, '', '', '{"key":"value"}')
+      const o = new ProcessOutput(
+        null,
+        null,
+        '{"key":"value"}',
+        '',
+        '{"key":"value"}'
+      )
       assert.deepEqual(o.json(), { key: 'value' })
     })
 


### PR DESCRIPTION
Fixes #1505.

`json()` ran `JSON.parse` on `stdall` (the combined stdout+stderr stream), so a well-behaved CLI that writes JSON to stdout and progress/prompts to stderr would break `json()` even though stdout alone contains valid JSON, matching the repro in the issue.

Fix: parse `stdout` instead. `stdout` is already tracked separately on `ProcessOutput`, so no new plumbing is needed.

The existing `json()` unit test happened to construct its fixture with the JSON payload in the `stdall` param and an empty `stdout`, which only worked because it was exercising the same bug this PR fixes — updated it to put the JSON in `stdout`, and added a new test that reproduces the issue's exact combined-stream scenario (JSON in stdout, unrelated text in stderr) and confirms `json()` now parses correctly. Verified the new test fails against the unpatched code and passes with the fix; full `core.test.js` suite (134 tests) passes.