### PR TITLE
docs: fix tmpfile('f2.txt') example output filename

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -328,7 +328,7 @@ Temp file factory.
 
 ```js
 f1 = tmpfile()         // /os/based/tmp/zx-1ra1iofojgg
-f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/foo.txt
+f2 = tmpfile('f2.txt')  // /os/based/tmp/zx-1ra1iofojgg/f2.txt
 f3 = tmpfile('f3.txt', 'string or buffer')
 f4 = tmpfile('f4.sh', 'echo "foo"', 0o744) // executable
 ```


### PR DESCRIPTION
## What
Fixes a typo in the `tmpfile()` example in `docs/api.md`. The example shows:

```js
f2 = tmpfile('f2.txt') // /os/based/tmp/zx-1ra1iofojgg/foo.txt
```

The output comment says `foo.txt`, but it should be `f2.txt` to match the filename actually passed into `tmpfile()`.

## Why
This is confusing for anyone reading the docs to understand how `tmpfile()` works — the output path doesn't match the input, making it look like the function renames the file for no reason.

## Change
Updated the comment from `foo.txt` to `f2.txt` in the example.

Fixes #1469