### PR TITLE
fix: prevent shell options from environment variables

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -163,10 +163,10 @@ Print the current `zx` version.
 Print help notes.
 
 ## Environment variables
-All the previously mentioned options can be set via the corresponding `ZX_`-prefixed environment variables.
+Most options can be set via the corresponding `ZX_`-prefixed environment variables. For security reasons, `shell`, `prefix`, and `postfix` cannot be set via environment variables.
 
 ```bash
-ZX_VERBOSE=true ZX_SHELL='/bin/bash' zx script.mjs
+ZX_VERBOSE=true zx script.mjs
 ```
     
 ```yaml
@@ -175,7 +175,6 @@ steps:
     run: zx script.mjs
     env:
       ZX_VERBOSE: true
-      ZX_SHELL: '/bin/bash'
 ```
 
 ## `__filename & __dirname`

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -35,7 +35,7 @@ There're many shell implementations. zx brings a few setup helpers:
 * [`usePowerShell`](./api#usepowershell) — PowerShell
 * [`usePwsh`](./api#usepwsh) — pwsh (PowerShell v7+)
 
-You can also set the shell directly via [JS API](./setup#bash), [CLI flags](./cli#shell) or [envars](./cli#environment-variables):
+You can also set the shell directly via [JS API](./setup#bash) or [CLI flags](./cli#shell):
 
 ```js
 $.shell = '/bin/zsh'
@@ -43,10 +43,6 @@ $.shell = '/bin/zsh'
 
 ```bash
 zx --shell /bin/zsh script.js
-```
-
-```bash
-ZX_SHELL=/bin/zsh zx script.js
 ```
 
 ## zx = bash + js

--- a/src/core.ts
+++ b/src/core.ts
@@ -84,9 +84,6 @@ const ENV_OPTS: Set<string> = new Set([
   'timeout',
   'timeoutSignal',
   'killSignal',
-  'prefix',
-  'postfix',
-  'shell',
 ])
 
 // prettier-ignore


### PR DESCRIPTION
Fixes #1435.
This change prevents ZX_SHELL, ZX_PREFIX, and ZX_POSTFIX from being used to configure shell execution through environment variables.
Changes
Removed shell, prefix, and postfix from ENV_OPTS in src/core.ts.
Updated docs/cli.md to document the security restriction.
Removed the ZX_SHELL environment-variable example from docs/shell.md.
Existing CLI and JavaScript API configuration remains available.
Testing
The relevant behavior was manually verified:
ZX_PREFIX is no longer loaded.
ZX_POSTFIX is no longer loaded.
ZX_SHELL is no longer loaded from the environment.
Other supported environment variables continue to work.
The full local test/pre-push suite could not be completed in my Windows environment due to environment-specific failures in the size, license, and circular-dependency checks.