### PR TITLE
fix(core): parse stdout only in ProcessOutput.json()

### DIFF
--- a/build/core.cjs
+++ b/build/core.cjs
@@ -1029,7 +1029,7 @@ var _ProcessOutput = class _ProcessOutput extends Error {
     return !this._dto.error && this.exitCode === 0;
   }
   json() {
-    return JSON.parse(this.stdall);
+    return JSON.parse(this.stdout);
   }
   buffer() {
     return import_node_buffer.Buffer.from(this.stdall);

--- a/src/core.ts
+++ b/src/core.ts
@@ -934,7 +934,7 @@ export class ProcessOutput extends Error {
   }
 
   json<T = any>(): T {
-    return JSON.parse(this.stdall)
+    return JSON.parse(this.stdout)
   }
 
   buffer(): Buffer {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1413,6 +1413,10 @@ describe('core', () => {
 
     test('json()', async () => {
       assert.deepEqual(await $`echo '{"key":"value"}'`.json(), { key: 'value' })
+      assert.deepEqual(
+        await $`echo '{"key":"value"}'; echo 'log progress' >&2`.json(),
+        { key: 'value' }
+      )
     })
 
     test('text()', async () => {
@@ -1502,7 +1506,13 @@ describe('core', () => {
     })
 
     test('json()', async () => {
-      const o = new ProcessOutput(null, null, '', '', '{"key":"value"}')
+      const o = new ProcessOutput(
+        null,
+        null,
+        '{"key":"value"}',
+        'non-json log',
+        '{"key":"value"}\nnon-json log'
+      )
       assert.deepEqual(o.json(), { key: 'value' })
     })
 


### PR DESCRIPTION
Fixes #1505

### Summary of Changes
- Updated `ProcessOutput.prototype.json()` in `src/core.ts` to parse `this.stdout` instead of `this.stdall` (combined stdout + stderr).
- Added unit test cases in `test/core.test.js` confirming that commands/ProcessOutput instances with non-JSON logs on `stderr` parse `stdout` JSON correctly without throwing parsing errors.